### PR TITLE
[ISSUE #664]关于'JMX-连接失败问题解决'的超链接修复

### DIFF
--- a/docs/user_guide/faq.md
+++ b/docs/user_guide/faq.md
@@ -37,7 +37,7 @@
 
 ## 8.4、`Jmx`连接失败如何解决？
 
-- 参看 [Jmx 连接配置&问题解决](./9-attachment#jmx-连接失败问题解决) 说明。
+- 参看 [Jmx 连接配置&问题解决](https://doc.knowstreaming.com/product/9-attachment#91jmx-%E8%BF%9E%E6%8E%A5%E5%A4%B1%E8%B4%A5%E9%97%AE%E9%A2%98%E8%A7%A3%E5%86%B3) 说明。
 
 &nbsp;
 


### PR DESCRIPTION
## 变更的目的是什么
[Jmx 连接配置&问题解决 #664](https://github.com/didi/KnowStreaming/issues/664)
修复正确的超链接

## 简短的更新日志

修复正确的超链接为[JMX-连接失败问题解决](https://doc.knowstreaming.com/product/9-attachment#91jmx-%E8%BF%9E%E6%8E%A5%E5%A4%B1%E8%B4%A5%E9%97%AE%E9%A2%98%E8%A7%A3%E5%86%B3)

## 验证这一变化

跳转访问 OK
![image](https://user-images.githubusercontent.com/18533252/195366373-4ce43214-06d9-4c5f-9b5a-0a6b0dc2f894.png)

