### PR TITLE
[ISSUE #678] zk-Latency avg为多位小数会抛出空指针

### DIFF
--- a/km-common/src/main/java/com/xiaojukeji/know/streaming/km/common/bean/entity/zookeeper/fourletterword/MonitorCmdData.java
+++ b/km-common/src/main/java/com/xiaojukeji/know/streaming/km/common/bean/entity/zookeeper/fourletterword/MonitorCmdData.java
@@ -22,7 +22,7 @@ import lombok.Data;
 @Data
 public class MonitorCmdData extends BaseFourLetterWordCmdData {
     private String zkVersion;
-    private Long zkAvgLatency;
+    private Float zkAvgLatency;
     private Long zkMaxLatency;
     private Long zkMinLatency;
     private Long zkPacketsReceived;

--- a/km-common/src/main/java/com/xiaojukeji/know/streaming/km/common/bean/entity/zookeeper/fourletterword/ServerCmdData.java
+++ b/km-common/src/main/java/com/xiaojukeji/know/streaming/km/common/bean/entity/zookeeper/fourletterword/ServerCmdData.java
@@ -17,7 +17,7 @@ import lombok.Data;
 @Data
 public class ServerCmdData extends BaseFourLetterWordCmdData {
     private String zkVersion;
-    private Long zkAvgLatency;
+    private Float zkAvgLatency;
     private Long zkMaxLatency;
     private Long zkMinLatency;
     private Long zkPacketsReceived;

--- a/km-common/src/main/java/com/xiaojukeji/know/streaming/km/common/bean/entity/zookeeper/fourletterword/parser/MonitorCmdDataParser.java
+++ b/km-common/src/main/java/com/xiaojukeji/know/streaming/km/common/bean/entity/zookeeper/fourletterword/parser/MonitorCmdDataParser.java
@@ -57,7 +57,7 @@ public class MonitorCmdDataParser implements FourLetterWordDataParser<MonitorCmd
                         monitorCmdData.setZkVersion(elem.getValue().split("-")[0]);
                         break;
                     case "zk_avg_latency":
-                        monitorCmdData.setZkAvgLatency(Long.valueOf(elem.getValue()));
+                        monitorCmdData.setZkAvgLatency(Float.valueOf(elem.getValue()));
                         break;
                     case "zk_max_latency":
                         monitorCmdData.setZkMaxLatency(Long.valueOf(elem.getValue()));

--- a/km-common/src/main/java/com/xiaojukeji/know/streaming/km/common/bean/entity/zookeeper/fourletterword/parser/ServerCmdDataParser.java
+++ b/km-common/src/main/java/com/xiaojukeji/know/streaming/km/common/bean/entity/zookeeper/fourletterword/parser/ServerCmdDataParser.java
@@ -54,7 +54,7 @@ public class ServerCmdDataParser implements FourLetterWordDataParser<ServerCmdDa
                     case "Latency min/avg/max":
                         String[] data = elem.getValue().split("/");
                         serverCmdData.setZkMinLatency(Long.valueOf(data[0]));
-                        serverCmdData.setZkAvgLatency(Long.valueOf(data[1]));
+                        serverCmdData.setZkAvgLatency(Float.valueOf(data[1]));
                         serverCmdData.setZkMaxLatency(Long.valueOf(data[2]));
                         break;
                     case "Received":


### PR DESCRIPTION
请不要在没有先创建Issue的情况下创建Pull Request。

## 变更的目的是什么

fix ISSUE #678 

## 简短的更新日志

1. 调整ServerCmdData,MonitorCmdData类中zkAvgLatency字段类型为Float

## 验证这一变化

![image](https://user-images.githubusercontent.com/49672871/195756346-6fa2bb38-ed82-4962-a2cb-49af01929344.png)

请遵循此清单，以帮助我们快速轻松地整合您的贡献：

* [x] 确保有针对更改提交的 Github issue（通常在您开始处理之前）。诸如拼写错误之类的琐碎更改不需要 Github issue。您的Pull Request应该只解决这个问题，而不需要进行其他更改——  一个 PR 解决一个问题。
* [x] 格式化 Pull Request 标题，如[ISSUE #xxxx] support Confluent Schema Registry。 Pull Request 中的每个提交都应该有一个有意义的主题行和正文。
* [x] 编写足够详细的Pull Request描述，以了解Pull Request的作用、方式和原因。
* [x] 编写必要的单元测试来验证您的逻辑更正。如果提交了新功能或重大更改，请记住在test 模块中添加 integration-test
* [x] 确保编译通过，集成测试通过

