### PR TITLE
[Optimize] 优化ZK指标的获取，减少重复采集的出现 (#709)

### DIFF
--- a/km-core/src/main/java/com/xiaojukeji/know/streaming/km/core/cache/ZookeeperLocalCache.java
+++ b/km-core/src/main/java/com/xiaojukeji/know/streaming/km/core/cache/ZookeeperLocalCache.java
@@ -1,0 +1,46 @@
+package com.xiaojukeji.know.streaming.km.core.cache;
+
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
+import com.xiaojukeji.know.streaming.km.common.bean.entity.zookeeper.fourletterword.BaseFourLetterWordCmdData;
+
+import java.util.concurrent.TimeUnit;
+
+public class ZookeeperLocalCache {
+    private static final Cache<String, String> fourLetterCmdFailedServerCache = Caffeine.newBuilder()
+            .expireAfterWrite(10, TimeUnit.MINUTES)
+            .maximumSize(10000)
+            .build();
+
+    private static final Cache<String, BaseFourLetterWordCmdData> fourLetterCmdDataCache = Caffeine.newBuilder()
+            .expireAfterWrite(60, TimeUnit.SECONDS)
+            .maximumSize(10000)
+            .build();
+
+    public static boolean canUse(String host, int port, String cmd) {
+        String data = fourLetterCmdFailedServerCache.getIfPresent(gen4lwFailedKey(host, port, cmd));
+
+        return data == null;
+    }
+
+    public static void setFailed(String host, int port, String cmd) {
+        fourLetterCmdFailedServerCache.put(gen4lwFailedKey(host, port, cmd), "");
+    }
+
+    public static BaseFourLetterWordCmdData getData(String host, int port, String cmd) {
+        return fourLetterCmdDataCache.getIfPresent(gen4lwFailedKey(host, port, cmd));
+    }
+
+    public static void putData(String host, int port, String cmd, BaseFourLetterWordCmdData cmdData) {
+        fourLetterCmdDataCache.put(gen4lwFailedKey(host, port, cmd), cmdData);
+    }
+
+    /**************************************************** private method ****************************************************/
+
+    private static String gen4lwFailedKey(String host, int port, String cmd) {
+        return host + "@" + port + "@" + cmd;
+    }
+
+
+
+}


### PR DESCRIPTION
1、避免不同集群，相同的ZK地址时，指标重复获取的情况；
2、避免集群某个ZK地址获取指标失败时，下一个周期还会继续尝试从该地址获取指标；

