### PR TITLE
[fix]Repair that preferredReplicaElection is not called as expected #248

### DIFF
--- a/km-common/src/main/java/com/xiaojukeji/know/streaming/km/common/bean/entity/reassign/ReassignResult.java
+++ b/km-common/src/main/java/com/xiaojukeji/know/streaming/km/common/bean/entity/reassign/ReassignResult.java
@@ -1,5 +1,6 @@
 package com.xiaojukeji.know.streaming.km.common.bean.entity.reassign;
 
+import com.xiaojukeji.know.streaming.km.common.utils.CommonUtils;
 import lombok.Data;
 import org.apache.kafka.common.TopicPartition;
 
@@ -18,5 +19,11 @@ public class ReassignResult {
         }
 
         return state.isDone();
+    }
+
+    public boolean checkPreferredReplicaElectionUnNeed(String reassignBrokerIds, String originalBrokerIds) {
+        Integer targetLeader = CommonUtils.string2IntList(reassignBrokerIds).get(0);
+        Integer originalLeader = CommonUtils.string2IntList(originalBrokerIds).get(0);
+        return originalLeader.equals(targetLeader);
     }
 }


### PR DESCRIPTION
## 变更的目的是什么
修复 preferredReplicaElection 方法未能如预期调用的问题 #248
<img width="1405" alt="image" src="https://user-images.githubusercontent.com/18533252/196962576-76f4e75f-2464-498d-861a-452f6519bd5c.png">
<img width="1421" alt="image" src="https://user-images.githubusercontent.com/18533252/196962636-8b687d57-1c01-46c1-a360-19a68627f46a.png">
reassignStateMap 中的

## 简短的更新日志
增加了迁移前 ISR 列表的首个 broker 与迁移后 ISR 列表的首个 broker 判别，若不同则触发优选副本切换为分区 leader

## 验证这一变化

<img width="1021" alt="WechatIMG1232" src="https://user-images.githubusercontent.com/18533252/196961895-0821486b-5994-4676-9722-514ac0ac844a.png">
