### PR TITLE
[Optimize] 删除Replica指标采集任务

### DIFF
--- a/km-collector/src/main/java/com/xiaojukeji/know/streaming/km/collector/metric/ReplicaMetricCollector.java
+++ b/km-collector/src/main/java/com/xiaojukeji/know/streaming/km/collector/metric/ReplicaMetricCollector.java
@@ -91,7 +91,7 @@ public class ReplicaMetricCollector extends AbstractMetricCollector<ReplicationM
                     continue;
                 }
 
-                Result<ReplicationMetrics> ret = replicaMetricService.collectReplicaMetricsFromKafkaWithCache(
+                Result<ReplicationMetrics> ret = replicaMetricService.collectReplicaMetricsFromKafka(
                         clusterPhyId,
                         metrics.getTopic(),
                         metrics.getBrokerId(),

--- a/km-core/src/main/java/com/xiaojukeji/know/streaming/km/core/cache/CollectedMetricsLocalCache.java
+++ b/km-core/src/main/java/com/xiaojukeji/know/streaming/km/core/cache/CollectedMetricsLocalCache.java
@@ -24,11 +24,6 @@ public class CollectedMetricsLocalCache {
             .maximumSize(10000)
             .build();
 
-    private static final Cache<String, Float> replicaMetricsValueCache = Caffeine.newBuilder()
-            .expireAfterWrite(90, TimeUnit.SECONDS)
-            .maximumSize(20000)
-            .build();
-
     public static Float getBrokerMetrics(String brokerMetricKey) {
         return brokerMetricsCache.getIfPresent(brokerMetricKey);
     }
@@ -62,17 +57,6 @@ public class CollectedMetricsLocalCache {
             return;
         }
         partitionMetricsCache.put(partitionMetricsKey, metricsList);
-    }
-
-    public static Float getReplicaMetrics(String replicaMetricsKey) {
-        return replicaMetricsValueCache.getIfPresent(replicaMetricsKey);
-    }
-
-    public static void putReplicaMetrics(String replicaMetricsKey, Float value) {
-        if (value == null) {
-            return;
-        }
-        replicaMetricsValueCache.put(replicaMetricsKey, value);
     }
 
     public static String genBrokerMetricKey(Long clusterPhyId, Integer brokerId, String metricName) {

--- a/km-core/src/main/java/com/xiaojukeji/know/streaming/km/core/service/replica/ReplicaMetricService.java
+++ b/km-core/src/main/java/com/xiaojukeji/know/streaming/km/core/service/replica/ReplicaMetricService.java
@@ -13,12 +13,14 @@ public interface ReplicaMetricService {
      * 从kafka中采集指标
      */
     Result<ReplicationMetrics> collectReplicaMetricsFromKafka(Long clusterId, String topic, Integer partitionId, Integer brokerId, String metric);
-    Result<ReplicationMetrics> collectReplicaMetricsFromKafkaWithCache(Long clusterPhyId, String topic, Integer brokerId, Integer partitionId, String metric);
+    Result<ReplicationMetrics> collectReplicaMetricsFromKafka(Long clusterId, String topicName, Integer partitionId, Integer brokerId, List<String> metricNameList);
 
     /**
      * 从ES中获取指标
      */
+    @Deprecated
     Result<List<MetricPointVO>> getMetricPointsFromES(Long clusterPhyId, Integer brokerId, String topicName, Integer partitionId, MetricDTO dto);
 
+    @Deprecated
     Result<ReplicationMetrics> getLatestMetricsFromES(Long clusterPhyId, Integer brokerId, String topicName, Integer partitionId, List<String> metricNames);
 }

--- a/km-rest/src/main/java/com/xiaojukeji/know/streaming/km/rest/api/v3/replica/ReplicaMetricsController.java
+++ b/km-rest/src/main/java/com/xiaojukeji/know/streaming/km/rest/api/v3/replica/ReplicaMetricsController.java
@@ -26,6 +26,7 @@ public class ReplicaMetricsController {
     @Autowired
     private ReplicaMetricService replicationMetricService;
 
+    @Deprecated
     @ApiOperation(value = "Replica指标-单个Replica")
     @PostMapping(value = "clusters/{clusterPhyId}/brokers/{brokerId}/topics/{topicName}/partitions/{partitionId}/metric-points")
     @ResponseBody
@@ -45,7 +46,7 @@ public class ReplicaMetricsController {
                                                       @PathVariable String topicName,
                                                       @PathVariable Integer partitionId,
                                                       @RequestBody List<String> metricsNames) {
-        Result<ReplicationMetrics> metricsResult = replicationMetricService.getLatestMetricsFromES(clusterPhyId, brokerId, topicName, partitionId, metricsNames);
+        Result<ReplicationMetrics> metricsResult = replicationMetricService.collectReplicaMetricsFromKafka(clusterPhyId, topicName, partitionId, brokerId, metricsNames);
         if (metricsResult.failed()) {
             return Result.buildFromIgnoreData(metricsResult);
         }

--- a/km-task/src/main/java/com/xiaojukeji/know/streaming/km/task/metrics/ReplicaMetricCollectorTask.java
+++ b/km-task/src/main/java/com/xiaojukeji/know/streaming/km/task/metrics/ReplicaMetricCollectorTask.java
@@ -1,32 +1,32 @@
-package com.xiaojukeji.know.streaming.km.task.metrics;
-
-import com.didiglobal.logi.job.annotation.Task;
-import com.didiglobal.logi.job.common.TaskResult;
-import com.didiglobal.logi.job.core.consensual.ConsensualEnum;
-import com.xiaojukeji.know.streaming.km.collector.metric.ReplicaMetricCollector;
-import com.xiaojukeji.know.streaming.km.common.bean.entity.cluster.ClusterPhy;
-import lombok.extern.slf4j.Slf4j;
-import org.springframework.beans.factory.annotation.Autowired;
-
-/**
- * @author didi
- */
-@Slf4j
-@Task(name = "ReplicaMetricCollectorTask",
-        description = "Replica指标采集任务",
-        cron = "0 0/1 * * * ? *",
-        autoRegister = true,
-        consensual = ConsensualEnum.BROADCAST,
-        timeout = 2 * 60)
-public class ReplicaMetricCollectorTask extends AbstractAsyncMetricsDispatchTask {
-
-    @Autowired
-    private ReplicaMetricCollector replicaMetricCollector;
-
-    @Override
-    public TaskResult processClusterTask(ClusterPhy clusterPhy, long triggerTimeUnitMs) throws Exception {
-        replicaMetricCollector.collectMetrics(clusterPhy);
-
-        return TaskResult.SUCCESS;
-    }
-}
+//package com.xiaojukeji.know.streaming.km.task.metrics;
+//
+//import com.didiglobal.logi.job.annotation.Task;
+//import com.didiglobal.logi.job.common.TaskResult;
+//import com.didiglobal.logi.job.core.consensual.ConsensualEnum;
+//import com.xiaojukeji.know.streaming.km.collector.metric.ReplicaMetricCollector;
+//import com.xiaojukeji.know.streaming.km.common.bean.entity.cluster.ClusterPhy;
+//import lombok.extern.slf4j.Slf4j;
+//import org.springframework.beans.factory.annotation.Autowired;
+//
+///**
+// * @author didi
+// */
+//@Slf4j
+//@Task(name = "ReplicaMetricCollectorTask",
+//        description = "Replica指标采集任务",
+//        cron = "0 0/1 * * * ? *",
+//        autoRegister = true,
+//        consensual = ConsensualEnum.BROADCAST,
+//        timeout = 2 * 60)
+//public class ReplicaMetricCollectorTask extends AbstractAsyncMetricsDispatchTask {
+//
+//    @Autowired
+//    private ReplicaMetricCollector replicaMetricCollector;
+//
+//    @Override
+//    public TaskResult processClusterTask(ClusterPhy clusterPhy, long triggerTimeUnitMs) throws Exception {
+//        replicaMetricCollector.collectMetrics(clusterPhy);
+//
+//        return TaskResult.SUCCESS;
+//    }
+//}


### PR DESCRIPTION
1、当集群存在较多副本时，指标采集的性能会严重降低；
2、Replica的指标基本上都是在实时获取时才需要，因此当前先将Replica指标采集任务关闭，后续依据产品需要再看是否开启；