### PR TITLE
[Optimize] 集群Broker列表中，补充Jmx是否成功连接的信息

### DIFF
--- a/km-common/src/main/java/com/xiaojukeji/know/streaming/km/common/bean/vo/cluster/res/ClusterBrokersOverviewVO.java
+++ b/km-common/src/main/java/com/xiaojukeji/know/streaming/km/common/bean/vo/cluster/res/ClusterBrokersOverviewVO.java
@@ -31,6 +31,9 @@ public class ClusterBrokersOverviewVO extends BrokerMetadataVO {
     @ApiModelProperty(value = "jmx端口")
     private Integer jmxPort;
 
+    @ApiModelProperty(value = "jmx连接状态 true:连接成功 false:连接失败")
+    private Boolean jmxConnected;
+
     @ApiModelProperty(value = "是否存活 true：存活 false：不存活")
     private Boolean alive;
 }


### PR DESCRIPTION
1、当前页面无数据时，一部分的原因是JMX连接失败导致；
2、Broker列表中增加是否连接成功的信息，便于问题的排查；
