### PR TITLE
For #718, 增加平台版本说明功能

### DIFF
--- a/km-console/packages/layout-clusters-fe/src/app.tsx
+++ b/km-console/packages/layout-clusters-fe/src/app.tsx
@@ -141,6 +141,9 @@ const AppContent = (props: { setlanguage: (language: string) => void }) => {
         ],
         isFixed: false,
         userDropMenuItems: [
+          <Menu.Item key={0}>
+            <a href="https://github.com/didi/KnowStreaming/releases" target="_blank">版本说明</a>
+          </Menu.Item>,
           <Menu.Item key={0} onClick={logout}>
             登出
           </Menu.Item>,

--- a/km-console/packages/layout-clusters-fe/src/app.tsx
+++ b/km-console/packages/layout-clusters-fe/src/app.tsx
@@ -144,7 +144,7 @@ const AppContent = (props: { setlanguage: (language: string) => void }) => {
           <Menu.Item key={0}>
             <a href="https://github.com/didi/KnowStreaming/releases" target="_blank">版本说明</a>
           </Menu.Item>,
-          <Menu.Item key={0} onClick={logout}>
+          <Menu.Item key={1} onClick={logout}>
             登出
           </Menu.Item>,
         ],


### PR DESCRIPTION
Fix: #718 

## 变更的目的是什么

优化：在平台上面增加显示具体的版本的功能

## 简短的更新日志

在鼠标移动到右上角头像的时候，会出现下拉选项，当前只有一个 "登出"。我们可以在 "登出"上面添加一个下拉项 "版本说明"，该选项为一个链接，会链接到github的[Releases](https://github.com/didi/KnowStreaming/releases)

## 验证这一变化

在鼠标移动到右上角头像的时候，会出现下拉选项，我们可以看到 “版本说明”项，该选项为一个链接，会链接到github的[Releases](https://github.com/didi/KnowStreaming/releases)

请遵循此清单，以帮助我们快速轻松地整合您的贡献：

* [ ] 确保有针对更改提交的 Github issue（通常在您开始处理之前）。诸如拼写错误之类的琐碎更改不需要 Github issue。您的Pull Request应该只解决这个问题，而不需要进行其他更改——  一个 PR 解决一个问题。
* [ ] 格式化 Pull Request 标题，如[ISSUE #123] support Confluent Schema Registry。 Pull Request 中的每个提交都应该有一个有意义的主题行和正文。
* [ ] 编写足够详细的Pull Request描述，以了解Pull Request的作用、方式和原因。
* [ ] 编写必要的单元测试来验证您的逻辑更正。如果提交了新功能或重大更改，请记住在test 模块中添加 integration-test
* [ ] 确保编译通过，集成测试通过

