### PR TITLE
[Bugfix]修复创建topic选择过期策略(kafka版本0.10.1.0之前)compact和delete只能二选一(didi#770)

### DIFF
--- a/km-core/src/main/java/com/xiaojukeji/know/streaming/km/core/service/version/fe/FrontEndControlVersionItems.java
+++ b/km-core/src/main/java/com/xiaojukeji/know/streaming/km/core/service/version/fe/FrontEndControlVersionItems.java
@@ -31,6 +31,8 @@ public class FrontEndControlVersionItems extends BaseMetricVersionMetric {
     private static final String FE_SECURITY_ACL_CREATE_RESOURCE_TYPE_TRANSACTIONAL_ID   = "FESecurityAclCreateResourceTypeTransactionalId";
     private static final String FE_SECURITY_ACL_CREATE_RESOURCE_TYPE_DELEGATION_TOKEN   = "FESecurityAclCreateResourceTypeDelegationToken";
 
+    private static final String FE_CREATE_TOPIC_CLEANUP_POLICY                          = "FECreateTopicCleanupPolicy";
+
     public FrontEndControlVersionItems(){}
 
     @Override
@@ -73,6 +75,10 @@ public class FrontEndControlVersionItems extends BaseMetricVersionMetric {
         // Security-创建ACL-ResourceType-DelegationToken
         itemList.add(buildItem().minVersion(VersionEnum.V_1_1_0).maxVersion(VersionEnum.V_MAX)
                 .name(FE_SECURITY_ACL_CREATE_RESOURCE_TYPE_DELEGATION_TOKEN).desc("Security-创建ACL-ResourceType-DelegationToken"));
+
+        // topic-创建-清理策略(delete和compact)V_0_10_1_0都可以选择
+        itemList.add(buildItem().minVersion(VersionEnum.V_0_10_1_0).maxVersion(VersionEnum.V_MAX)
+                .name(FE_CREATE_TOPIC_CLEANUP_POLICY).desc("Topic-创建Topic-Cleanup-Policy"));
 
         return itemList;
     }


### PR DESCRIPTION
[Bugfix]修复创建topic选择过期策略(kafka版本0.10.1.0之前)compact和delete只能二选一(didi#770)
主要完成后端部分，前端部分待前端比较熟悉的同学完善下