### PR TITLE
[Bugfix]修复集群Topic列表页面白屏问题(#819)

### DIFF
--- a/km-console/packages/layout-clusters-fe/src/pages/TopicList/config.tsx
+++ b/km-console/packages/layout-clusters-fe/src/pages/TopicList/config.tsx
@@ -23,3 +23,11 @@ export const getChartConfig = (title: string) => {
     },
   };
 };
+
+export const HealthStateMap: any = {
+  '-1': 'Unknown',
+  0: '好',
+  1: '中',
+  2: '差',
+  3: 'Down',
+};

--- a/km-console/packages/layout-clusters-fe/src/pages/TopicList/index.tsx
+++ b/km-console/packages/layout-clusters-fe/src/pages/TopicList/index.tsx
@@ -18,7 +18,7 @@ import ReplicaMove from '@src/components/TopicJob/ReplicaMove';
 import { formatAssignSize } from '../Jobs/config';
 import { DownOutlined } from '@ant-design/icons';
 import { tableHeaderPrefix } from '@src/constants/common';
-import {sliderValueMap} from "@src/pages/MutliClusterPage/config";
+import { HealthStateMap } from './config';
 
 const { Option } = Select;
 
@@ -92,8 +92,7 @@ const AutoPage = (props: any) => {
     const orgVal = record?.latestMetrics?.metrics?.[metricName];
     if (orgVal !== undefined) {
       if (metricName === 'HealthState') {
-        const val = sliderValueMap[(orgVal) as keyof typeof sliderValueMap];
-        return  val.name;
+        return HealthStateMap[orgVal] || '-';
       } else if (metricName === 'LogSize') {
         return Number(Utils.formatAssignSize(orgVal, 'MB')).toLocaleString();
       } else {
@@ -165,8 +164,8 @@ const AutoPage = (props: any) => {
         sorter: true,
         // 设计图上量出来的是144，但做的时候发现写144 header部分的sort箭头不出来，所以临时调大些
         width: 170,
-        render: (value: any, record: any) =>{
-          return calcCurValue(record, "HealthState")
+        render: (value: any, record: any) => {
+          return calcCurValue(record, 'HealthState');
         },
       },
       // {


### PR DESCRIPTION
集群Topic列表健康状态对应关系存在问题，导致当健康状态指标存在时，会出现白屏。

Fix #819 