### PR TITLE
[Bugfix]修复“group消费topic的partition显示不全”问题(#781)

### DIFF
--- a/km-console/packages/layout-clusters-fe/src/pages/ConsumerGroup/ExpandedRow.tsx
+++ b/km-console/packages/layout-clusters-fe/src/pages/ConsumerGroup/ExpandedRow.tsx
@@ -167,8 +167,11 @@ export const ExpandedRow: any = ({ record, groupName }: any) => {
     )
       .then((data: any) => {
         if (!data) return;
-        setPagination((origin: any) => {
-          return { ...origin, current: data.pagination?.pageNo, pageSize: data.pagination?.pageSize };
+
+        setPagination({
+          current: data.pagination?.pageNo,
+          pageSize: data.pagination?.pageSize,
+          total: data.pagination?.total,
         });
         setConsumerList(data?.bizData || []);
       })


### PR DESCRIPTION
请不要在没有先创建Issue的情况下创建Pull Request。

## 变更的目的是什么

修复“group消费topic的partition显示不全”问题

## 简短的更新日志

修改分页显示问题

## 验证这一变化

经过修复后，可以正常显示多页的partition数据。

<img width="1435" alt="image" src="https://user-images.githubusercontent.com/24537059/209626022-a82518d3-51db-47a7-bfce-150aab832fd4.png">

请遵循此清单，以帮助我们快速轻松地整合您的贡献：

* [ ] 确保有针对更改提交的 Github issue（通常在您开始处理之前）。诸如拼写错误之类的琐碎更改不需要 Github issue。您的Pull Request应该只解决这个问题，而不需要进行其他更改——  一个 PR 解决一个问题。
* [ ] 格式化 Pull Request 标题，如[ISSUE #123] support Confluent Schema Registry。 Pull Request 中的每个提交都应该有一个有意义的主题行和正文。
* [ ] 编写足够详细的Pull Request描述，以了解Pull Request的作用、方式和原因。
* [ ] 编写必要的单元测试来验证您的逻辑更正。如果提交了新功能或重大更改，请记住在test 模块中添加 integration-test
* [ ] 确保编译通过，集成测试通过

