### PR TITLE
[Optimize]无ZK模块时，巡检详情忽略对ZK的展示(#764)

### DIFF
--- a/km-common/src/main/java/com/xiaojukeji/know/streaming/km/common/bean/vo/health/HealthScoreBaseResultVO.java
+++ b/km-common/src/main/java/com/xiaojukeji/know/streaming/km/common/bean/vo/health/HealthScoreBaseResultVO.java
@@ -33,10 +33,6 @@ public class HealthScoreBaseResultVO extends BaseTimeVO {
     @ApiModelProperty(value="检查说明", example = "Group延迟")
     private String configDesc;
 
-    @Deprecated
-    @ApiModelProperty(value="得分", example = "100")
-    private Integer score = 100;
-
     @ApiModelProperty(value="结果", example = "true")
     private Boolean passed;
 

--- a/km-core/src/main/java/com/xiaojukeji/know/streaming/km/core/service/health/checker/AbstractHealthCheckService.java
+++ b/km-core/src/main/java/com/xiaojukeji/know/streaming/km/core/service/health/checker/AbstractHealthCheckService.java
@@ -28,6 +28,8 @@ public abstract class AbstractHealthCheckService {
 
     public abstract HealthCheckDimensionEnum getHealthCheckDimensionEnum();
 
+    public abstract Integer getDimensionCodeIfSupport(Long kafkaClusterPhyId);
+
     public HealthCheckResult checkAndGetResult(ClusterParam clusterParam, BaseClusterHealthConfig clusterHealthConfig) {
         if (ValidateUtils.anyNull(clusterParam, clusterHealthConfig)) {
             return null;

--- a/km-core/src/main/java/com/xiaojukeji/know/streaming/km/core/service/health/checker/broker/HealthCheckBrokerService.java
+++ b/km-core/src/main/java/com/xiaojukeji/know/streaming/km/core/service/health/checker/broker/HealthCheckBrokerService.java
@@ -57,6 +57,11 @@ public class HealthCheckBrokerService extends AbstractHealthCheckService {
         return HealthCheckDimensionEnum.BROKER;
     }
 
+    @Override
+    public Integer getDimensionCodeIfSupport(Long kafkaClusterPhyId) {
+        return this.getHealthCheckDimensionEnum().getDimension();
+    }
+
     /**
      * Broker网络处理线程平均值过低
      */

--- a/km-core/src/main/java/com/xiaojukeji/know/streaming/km/core/service/health/checker/cluster/HealthCheckClusterService.java
+++ b/km-core/src/main/java/com/xiaojukeji/know/streaming/km/core/service/health/checker/cluster/HealthCheckClusterService.java
@@ -44,6 +44,11 @@ public class HealthCheckClusterService extends AbstractHealthCheckService {
         return HealthCheckDimensionEnum.CLUSTER;
     }
 
+    @Override
+    public Integer getDimensionCodeIfSupport(Long kafkaClusterPhyId) {
+        return this.getHealthCheckDimensionEnum().getDimension();
+    }
+
     /**
      * 检查NoController
      */

--- a/km-core/src/main/java/com/xiaojukeji/know/streaming/km/core/service/health/checker/connect/HealthCheckConnectClusterService.java
+++ b/km-core/src/main/java/com/xiaojukeji/know/streaming/km/core/service/health/checker/connect/HealthCheckConnectClusterService.java
@@ -14,7 +14,9 @@ import com.xiaojukeji.know.streaming.km.common.constant.Constant;
 import com.xiaojukeji.know.streaming.km.common.enums.health.HealthCheckDimensionEnum;
 import com.xiaojukeji.know.streaming.km.common.enums.health.HealthCheckNameEnum;
 import com.xiaojukeji.know.streaming.km.common.utils.Tuple;
+import com.xiaojukeji.know.streaming.km.common.utils.ValidateUtils;
 import com.xiaojukeji.know.streaming.km.core.service.connect.cluster.ConnectClusterMetricService;
+import com.xiaojukeji.know.streaming.km.core.service.connect.cluster.ConnectClusterService;
 import com.xiaojukeji.know.streaming.km.core.service.health.checker.AbstractHealthCheckService;
 import com.xiaojukeji.know.streaming.km.persistence.connect.cache.LoadedConnectClusterCache;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -32,8 +34,10 @@ import static com.xiaojukeji.know.streaming.km.core.service.version.metrics.conn
  */
 @Service
 public class HealthCheckConnectClusterService extends AbstractHealthCheckService {
-
     private static final ILog log = LogFactory.getLog(HealthCheckConnectClusterService.class);
+
+    @Autowired
+    private ConnectClusterService connectClusterService;
 
     @Autowired
     private ConnectClusterMetricService connectClusterMetricService;
@@ -55,6 +59,16 @@ public class HealthCheckConnectClusterService extends AbstractHealthCheckService
     @Override
     public HealthCheckDimensionEnum getHealthCheckDimensionEnum() {
         return HealthCheckDimensionEnum.CONNECT_CLUSTER;
+    }
+
+    @Override
+    public Integer getDimensionCodeIfSupport(Long kafkaClusterPhyId) {
+        List<ConnectCluster> clusterList = connectClusterService.listByKafkaCluster(kafkaClusterPhyId);
+        if (ValidateUtils.isEmptyList(clusterList)) {
+            return null;
+        }
+
+        return this.getHealthCheckDimensionEnum().getDimension();
     }
 
     private HealthCheckResult checkStartupFailurePercentage(Tuple<ClusterParam, BaseClusterHealthConfig> paramTuple) {

--- a/km-core/src/main/java/com/xiaojukeji/know/streaming/km/core/service/health/checker/connect/HealthCheckConnectorService.java
+++ b/km-core/src/main/java/com/xiaojukeji/know/streaming/km/core/service/health/checker/connect/HealthCheckConnectorService.java
@@ -4,6 +4,7 @@ import com.didiglobal.logi.log.ILog;
 import com.didiglobal.logi.log.LogFactory;
 import com.xiaojukeji.know.streaming.km.common.bean.entity.config.healthcheck.BaseClusterHealthConfig;
 import com.xiaojukeji.know.streaming.km.common.bean.entity.config.healthcheck.HealthCompareValueConfig;
+import com.xiaojukeji.know.streaming.km.common.bean.entity.connect.ConnectCluster;
 import com.xiaojukeji.know.streaming.km.common.bean.entity.health.HealthCheckResult;
 import com.xiaojukeji.know.streaming.km.common.bean.entity.metrics.connect.ConnectorMetrics;
 import com.xiaojukeji.know.streaming.km.common.bean.entity.param.cluster.ClusterParam;
@@ -13,6 +14,8 @@ import com.xiaojukeji.know.streaming.km.common.constant.Constant;
 import com.xiaojukeji.know.streaming.km.common.enums.health.HealthCheckDimensionEnum;
 import com.xiaojukeji.know.streaming.km.common.enums.health.HealthCheckNameEnum;
 import com.xiaojukeji.know.streaming.km.common.utils.Tuple;
+import com.xiaojukeji.know.streaming.km.common.utils.ValidateUtils;
+import com.xiaojukeji.know.streaming.km.core.service.connect.cluster.ConnectClusterService;
 import com.xiaojukeji.know.streaming.km.core.service.connect.connector.ConnectorMetricService;
 import com.xiaojukeji.know.streaming.km.core.service.connect.connector.ConnectorService;
 import com.xiaojukeji.know.streaming.km.core.service.health.checker.AbstractHealthCheckService;
@@ -32,10 +35,13 @@ import static com.xiaojukeji.know.streaming.km.core.service.version.metrics.conn
  */
 @Service
 public class HealthCheckConnectorService extends AbstractHealthCheckService {
-
     private static final ILog log = LogFactory.getLog(HealthCheckConnectorService.class);
+
     @Autowired
     private ConnectorService connectorService;
+
+    @Autowired
+    private ConnectClusterService connectClusterService;
 
     @Autowired
     private ConnectorMetricService connectorMetricService;
@@ -64,6 +70,16 @@ public class HealthCheckConnectorService extends AbstractHealthCheckService {
     @Override
     public HealthCheckDimensionEnum getHealthCheckDimensionEnum() {
         return HealthCheckDimensionEnum.CONNECTOR;
+    }
+
+    @Override
+    public Integer getDimensionCodeIfSupport(Long kafkaClusterPhyId) {
+        List<ConnectCluster> clusterList = connectClusterService.listByKafkaCluster(kafkaClusterPhyId);
+        if (ValidateUtils.isEmptyList(clusterList)) {
+            return null;
+        }
+
+        return this.getHealthCheckDimensionEnum().getDimension();
     }
 
     private HealthCheckResult checkFailedTaskCount(Tuple<ClusterParam, BaseClusterHealthConfig> paramTuple) {

--- a/km-core/src/main/java/com/xiaojukeji/know/streaming/km/core/service/health/checker/group/HealthCheckGroupService.java
+++ b/km-core/src/main/java/com/xiaojukeji/know/streaming/km/core/service/health/checker/group/HealthCheckGroupService.java
@@ -51,6 +51,11 @@ public class HealthCheckGroupService extends AbstractHealthCheckService {
         return HealthCheckDimensionEnum.GROUP;
     }
 
+    @Override
+    public Integer getDimensionCodeIfSupport(Long kafkaClusterPhyId) {
+        return this.getHealthCheckDimensionEnum().getDimension();
+    }
+
     /**
      * 检查Group re-balance太频繁
      */

--- a/km-core/src/main/java/com/xiaojukeji/know/streaming/km/core/service/health/checker/topic/HealthCheckTopicService.java
+++ b/km-core/src/main/java/com/xiaojukeji/know/streaming/km/core/service/health/checker/topic/HealthCheckTopicService.java
@@ -62,6 +62,11 @@ public class HealthCheckTopicService extends AbstractHealthCheckService {
         return HealthCheckDimensionEnum.TOPIC;
     }
 
+    @Override
+    public Integer getDimensionCodeIfSupport(Long kafkaClusterPhyId) {
+        return this.getHealthCheckDimensionEnum().getDimension();
+    }
+
     /**
      * 检查Topic长期未同步
      */

--- a/km-core/src/main/java/com/xiaojukeji/know/streaming/km/core/service/health/checker/zookeeper/HealthCheckZookeeperService.java
+++ b/km-core/src/main/java/com/xiaojukeji/know/streaming/km/core/service/health/checker/zookeeper/HealthCheckZookeeperService.java
@@ -19,6 +19,7 @@ import com.xiaojukeji.know.streaming.km.common.enums.health.HealthCheckNameEnum;
 import com.xiaojukeji.know.streaming.km.common.enums.zookeeper.ZKRoleEnum;
 import com.xiaojukeji.know.streaming.km.common.utils.ConvertUtil;
 import com.xiaojukeji.know.streaming.km.common.utils.Tuple;
+import com.xiaojukeji.know.streaming.km.common.utils.ValidateUtils;
 import com.xiaojukeji.know.streaming.km.common.utils.zookeeper.ZookeeperUtils;
 import com.xiaojukeji.know.streaming.km.core.service.health.checker.AbstractHealthCheckService;
 import com.xiaojukeji.know.streaming.km.core.service.version.metrics.kafka.ZookeeperMetricVersionItems;
@@ -56,7 +57,7 @@ public class HealthCheckZookeeperService extends AbstractHealthCheckService {
     @Override
     public List<ClusterParam> getResList(Long clusterPhyId) {
         ClusterPhy clusterPhy = LoadedClusterPhyCache.getByPhyId(clusterPhyId);
-        if (clusterPhy == null) {
+        if (clusterPhy == null || ValidateUtils.isBlank(clusterPhy.getZookeeper())) {
             return new ArrayList<>();
         }
 
@@ -78,6 +79,15 @@ public class HealthCheckZookeeperService extends AbstractHealthCheckService {
     @Override
     public HealthCheckDimensionEnum getHealthCheckDimensionEnum() {
         return HealthCheckDimensionEnum.ZOOKEEPER;
+    }
+
+    @Override
+    public Integer getDimensionCodeIfSupport(Long kafkaClusterPhyId) {
+        if (ValidateUtils.isEmptyList(this.getResList(kafkaClusterPhyId))) {
+            return null;
+        }
+
+        return this.getHealthCheckDimensionEnum().getDimension();
     }
 
     private HealthCheckResult checkBrainSplit(Tuple<ClusterParam, BaseClusterHealthConfig> singleConfigSimpleTuple) {

--- a/km-core/src/main/java/com/xiaojukeji/know/streaming/km/core/service/health/state/HealthStateService.java
+++ b/km-core/src/main/java/com/xiaojukeji/know/streaming/km/core/service/health/state/HealthStateService.java
@@ -3,7 +3,6 @@ package com.xiaojukeji.know.streaming.km.core.service.health.state;
 import com.xiaojukeji.know.streaming.km.common.bean.entity.health.HealthScoreResult;
 import com.xiaojukeji.know.streaming.km.common.bean.entity.metrics.*;
 import com.xiaojukeji.know.streaming.km.common.bean.entity.metrics.connect.ConnectorMetrics;
-import com.xiaojukeji.know.streaming.km.common.enums.health.HealthCheckDimensionEnum;
 
 import java.util.List;
 
@@ -22,8 +21,7 @@ public interface HealthStateService {
     /**
      * 获取集群健康检查结果
      */
-    List<HealthScoreResult> getClusterHealthResult(Long clusterPhyId);
-    List<HealthScoreResult> getDimensionHealthResult(Long clusterPhyId, HealthCheckDimensionEnum dimensionEnum);
+    List<HealthScoreResult> getAllDimensionHealthResult(Long clusterPhyId);
     List<HealthScoreResult> getDimensionHealthResult(Long clusterPhyId, List<Integer> dimensionCodeList);
     List<HealthScoreResult> getResHealthResult(Long clusterPhyId, Long clusterId, Integer dimension, String resNme);
 }

--- a/km-rest/src/main/java/com/xiaojukeji/know/streaming/km/rest/api/v3/health/KafkaHealthController.java
+++ b/km-rest/src/main/java/com/xiaojukeji/know/streaming/km/rest/api/v3/health/KafkaHealthController.java
@@ -17,7 +17,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.ArrayList;
-import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 
 /**
@@ -31,14 +31,6 @@ public class KafkaHealthController {
     @Autowired
     private HealthStateService healthStateService;
 
-    private List<Integer> allDimensionCodeList = new ArrayList<Integer>() {
-        {
-            for (HealthCheckDimensionEnum dimensionEnum : HealthCheckDimensionEnum.values()) {
-                add(dimensionEnum.getDimension());
-            }
-        }
-    };
-
     @Autowired
     private HealthCheckResultService healthCheckResultService;
 
@@ -49,12 +41,18 @@ public class KafkaHealthController {
                                                                                      @RequestParam(required = false) Integer dimensionCode) {
         HealthCheckDimensionEnum dimensionEnum = HealthCheckDimensionEnum.getByCode(dimensionCode);
         if (!dimensionEnum.equals(HealthCheckDimensionEnum.UNKNOWN)) {
-            return Result.buildSuc(HealthScoreVOConverter.convert2HealthScoreResultDetailVOList(healthStateService.getDimensionHealthResult(clusterPhyId, Arrays.asList(dimensionCode))));
+            return Result.buildSuc(
+                    HealthScoreVOConverter.convert2HealthScoreResultDetailVOList(
+                            healthStateService.getDimensionHealthResult(clusterPhyId, Collections.singletonList(dimensionCode))
+                    )
+            );
         }
 
-        return Result.buildSuc(HealthScoreVOConverter.convert2HealthScoreResultDetailVOList(
-                healthStateService.getDimensionHealthResult(clusterPhyId, allDimensionCodeList)
-        ));
+        return Result.buildSuc(
+                HealthScoreVOConverter.convert2HealthScoreResultDetailVOList(
+                        healthStateService.getAllDimensionHealthResult(clusterPhyId)
+                )
+        );
     }
 
     @ApiOperation(value = "集群-健康检查详情")


### PR DESCRIPTION
Fix #764 