### PR TITLE
fix:进行Kafka-Controller健康巡检时，由于查询ES异常导致会抛出空指针异常，但是日志提示不明显 #869

### DIFF
--- a/km-core/src/main/java/com/xiaojukeji/know/streaming/km/core/service/health/checker/cluster/HealthCheckClusterService.java
+++ b/km-core/src/main/java/com/xiaojukeji/know/streaming/km/core/service/health/checker/cluster/HealthCheckClusterService.java
@@ -71,7 +71,11 @@ public class HealthCheckClusterService extends AbstractHealthCheckService {
         );
 
         Float activeController = clusterMetricsResult.getData().getMetric(ClusterMetricVersionItems.CLUSTER_METRIC_ACTIVE_CONTROLLER_COUNT);
-
+        if (activeController == null) {
+            log.error("method=checkClusterNoController||param={}||config={}||errMsg=get metrics failed, activeControllerCount is null",
+                    param, valueConfig);
+            return null;
+        }
 
         checkResult.setPassed(activeController.intValue() != valueConfig.getValue().intValue() ? 0: 1);
 

--- a/km-core/src/main/java/com/xiaojukeji/know/streaming/km/core/service/health/checker/cluster/HealthCheckClusterService.java
+++ b/km-core/src/main/java/com/xiaojukeji/know/streaming/km/core/service/health/checker/cluster/HealthCheckClusterService.java
@@ -58,7 +58,7 @@ public class HealthCheckClusterService extends AbstractHealthCheckService {
 
         Result<ClusterMetrics> clusterMetricsResult = clusterMetricService.getLatestMetricsFromES(param.getClusterPhyId(), Arrays.asList(ClusterMetricVersionItems.CLUSTER_METRIC_ACTIVE_CONTROLLER_COUNT));
         if (clusterMetricsResult.failed() || !clusterMetricsResult.hasData()) {
-            log.error("method=checkClusterNoController||param={}||config={}||result={}||errMsg=get metrics failed",
+            log.error("method=checkClusterNoController||param={}||config={}||result={}||errMsg=get metrics from es failed",
                     param, valueConfig, clusterMetricsResult);
             return null;
         }
@@ -72,7 +72,7 @@ public class HealthCheckClusterService extends AbstractHealthCheckService {
 
         Float activeController = clusterMetricsResult.getData().getMetric(ClusterMetricVersionItems.CLUSTER_METRIC_ACTIVE_CONTROLLER_COUNT);
         if (activeController == null) {
-            log.error("method=checkClusterNoController||param={}||config={}||errMsg=get metrics failed, activeControllerCount is null",
+            log.error("method=checkClusterNoController||param={}||config={}||errMsg=get metrics from es failed, activeControllerCount is null",
                     param, valueConfig);
             return null;
         }


### PR DESCRIPTION
请不要在没有先创建Issue的情况下创建Pull Request。

## 变更的目的是什么

优化错误日志，明确错误原因

## 简短的更新日志

当通过es获取的activeControllerCount指标为null时，优化错误日志

## 验证这一变化

当通过es获取的activeControllerCount指标为null时错误日志为get metrics failed, activeControllerCount is null。。。

请遵循此清单，以帮助我们快速轻松地整合您的贡献：

* [ ] 一个 PR（Pull Request的简写）只解决一个问题，禁止一个 PR 解决多个问题；
* [ ] 确保 PR 有对应的 Issue（通常在您开始处理之前创建），除非是书写错误之类的琐碎更改不需要 Issue ；
* [ ] 格式化 PR 及 Commit-Log 的标题及内容，例如 #861 。PS：Commit-Log 需要在 Git Commit 代码时进行填写，在 GitHub 上修改不了；
* [ ] 编写足够详细的 PR 描述，以了解 PR 的作用、方式和原因；
* [ ] 编写必要的单元测试来验证您的逻辑更正。如果提交了新功能或重大更改，请记住在 test 模块中添加 integration-test；
* [ ] 确保编译通过，集成测试通过；

