### PR TITLE
[Bugfix]解决在解析命令执行后返回指标的值时发生的数据类型转换错误与指标存储上报时报空指针的问题

### DIFF
--- a/km-common/src/main/java/com/xiaojukeji/know/streaming/km/common/bean/entity/zookeeper/fourletterword/MonitorCmdData.java
+++ b/km-common/src/main/java/com/xiaojukeji/know/streaming/km/common/bean/entity/zookeeper/fourletterword/MonitorCmdData.java
@@ -23,8 +23,8 @@ import lombok.Data;
 public class MonitorCmdData extends BaseFourLetterWordCmdData {
     private String zkVersion;
     private Float zkAvgLatency;
-    private Long zkMaxLatency;
-    private Long zkMinLatency;
+    private Float zkMaxLatency;
+    private Float zkMinLatency;
     private Long zkPacketsReceived;
     private Long zkPacketsSent;
     private Long zkNumAliveConnections;

--- a/km-common/src/main/java/com/xiaojukeji/know/streaming/km/common/bean/entity/zookeeper/fourletterword/ServerCmdData.java
+++ b/km-common/src/main/java/com/xiaojukeji/know/streaming/km/common/bean/entity/zookeeper/fourletterword/ServerCmdData.java
@@ -18,8 +18,8 @@ import lombok.Data;
 public class ServerCmdData extends BaseFourLetterWordCmdData {
     private String zkVersion;
     private Float zkAvgLatency;
-    private Long zkMaxLatency;
-    private Long zkMinLatency;
+    private Float zkMaxLatency;
+    private Float zkMinLatency;
     private Long zkPacketsReceived;
     private Long zkPacketsSent;
     private Long zkNumAliveConnections;

--- a/km-common/src/main/java/com/xiaojukeji/know/streaming/km/common/bean/entity/zookeeper/fourletterword/parser/MonitorCmdDataParser.java
+++ b/km-common/src/main/java/com/xiaojukeji/know/streaming/km/common/bean/entity/zookeeper/fourletterword/parser/MonitorCmdDataParser.java
@@ -3,6 +3,7 @@ package com.xiaojukeji.know.streaming.km.common.bean.entity.zookeeper.fourletter
 import com.didiglobal.logi.log.ILog;
 import com.didiglobal.logi.log.LogFactory;
 import com.xiaojukeji.know.streaming.km.common.bean.entity.zookeeper.fourletterword.MonitorCmdData;
+import com.xiaojukeji.know.streaming.km.common.utils.ConvertUtil;
 import com.xiaojukeji.know.streaming.km.common.utils.zookeeper.FourLetterWordUtil;
 import lombok.Data;
 
@@ -57,13 +58,13 @@ public class MonitorCmdDataParser implements FourLetterWordDataParser<MonitorCmd
                         monitorCmdData.setZkVersion(elem.getValue().split("-")[0]);
                         break;
                     case "zk_avg_latency":
-                        monitorCmdData.setZkAvgLatency(Float.valueOf(elem.getValue()));
+                        monitorCmdData.setZkAvgLatency(ConvertUtil.string2Float(elem.getValue()));
                         break;
                     case "zk_max_latency":
-                        monitorCmdData.setZkMaxLatency(Long.valueOf(elem.getValue()));
+                        monitorCmdData.setZkMaxLatency(ConvertUtil.string2Float(elem.getValue()));
                         break;
                     case "zk_min_latency":
-                        monitorCmdData.setZkMinLatency(Long.valueOf(elem.getValue()));
+                        monitorCmdData.setZkMinLatency(ConvertUtil.string2Float(elem.getValue()));
                         break;
                     case "zk_packets_received":
                         monitorCmdData.setZkPacketsReceived(Long.valueOf(elem.getValue()));

--- a/km-common/src/main/java/com/xiaojukeji/know/streaming/km/common/bean/entity/zookeeper/fourletterword/parser/ServerCmdDataParser.java
+++ b/km-common/src/main/java/com/xiaojukeji/know/streaming/km/common/bean/entity/zookeeper/fourletterword/parser/ServerCmdDataParser.java
@@ -3,6 +3,7 @@ package com.xiaojukeji.know.streaming.km.common.bean.entity.zookeeper.fourletter
 import com.didiglobal.logi.log.ILog;
 import com.didiglobal.logi.log.LogFactory;
 import com.xiaojukeji.know.streaming.km.common.bean.entity.zookeeper.fourletterword.ServerCmdData;
+import com.xiaojukeji.know.streaming.km.common.utils.ConvertUtil;
 import com.xiaojukeji.know.streaming.km.common.utils.zookeeper.FourLetterWordUtil;
 import lombok.Data;
 
@@ -53,9 +54,9 @@ public class ServerCmdDataParser implements FourLetterWordDataParser<ServerCmdDa
                         break;
                     case "Latency min/avg/max":
                         String[] data = elem.getValue().split("/");
-                        serverCmdData.setZkMinLatency(Long.valueOf(data[0]));
-                        serverCmdData.setZkAvgLatency(Float.valueOf(data[1]));
-                        serverCmdData.setZkMaxLatency(Long.valueOf(data[2]));
+                        serverCmdData.setZkMinLatency(ConvertUtil.string2Float(data[0]));
+                        serverCmdData.setZkAvgLatency(ConvertUtil.string2Float(data[1]));
+                        serverCmdData.setZkMaxLatency(ConvertUtil.string2Float(data[2]));
                         break;
                     case "Received":
                         serverCmdData.setZkPacketsReceived(Long.valueOf(elem.getValue()));

--- a/km-core/src/main/java/com/xiaojukeji/know/streaming/km/core/service/zookeeper/impl/ZookeeperMetricServiceImpl.java
+++ b/km-core/src/main/java/com/xiaojukeji/know/streaming/km/core/service/zookeeper/impl/ZookeeperMetricServiceImpl.java
@@ -206,8 +206,8 @@ public class ZookeeperMetricServiceImpl extends BaseMetricService implements Zoo
 
             ZookeeperMetrics metrics = new ZookeeperMetrics(param.getClusterPhyId());
             metrics.putMetric(ZOOKEEPER_METRIC_AVG_REQUEST_LATENCY,         cmdData.getZkAvgLatency());
-            metrics.putMetric(ZOOKEEPER_METRIC_MIN_REQUEST_LATENCY,         cmdData.getZkMinLatency().floatValue());
-            metrics.putMetric(ZOOKEEPER_METRIC_MAX_REQUEST_LATENCY,         cmdData.getZkMaxLatency().floatValue());
+            metrics.putMetric(ZOOKEEPER_METRIC_MIN_REQUEST_LATENCY,         cmdData.getZkMinLatency());
+            metrics.putMetric(ZOOKEEPER_METRIC_MAX_REQUEST_LATENCY,         cmdData.getZkMaxLatency());
             metrics.putMetric(ZOOKEEPER_METRIC_OUTSTANDING_REQUESTS,        cmdData.getZkOutstandingRequests().floatValue());
             metrics.putMetric(ZOOKEEPER_METRIC_NODE_COUNT,                  cmdData.getZkZnodeCount().floatValue());
             metrics.putMetric(ZOOKEEPER_METRIC_NUM_ALIVE_CONNECTIONS,       cmdData.getZkNumAliveConnections().floatValue());
@@ -255,8 +255,8 @@ public class ZookeeperMetricServiceImpl extends BaseMetricService implements Zoo
 
             ZookeeperMetrics metrics = new ZookeeperMetrics(param.getClusterPhyId());
             metrics.putMetric(ZOOKEEPER_METRIC_AVG_REQUEST_LATENCY,         cmdData.getZkAvgLatency());
-            metrics.putMetric(ZOOKEEPER_METRIC_MIN_REQUEST_LATENCY,         cmdData.getZkMinLatency().floatValue());
-            metrics.putMetric(ZOOKEEPER_METRIC_MAX_REQUEST_LATENCY,         cmdData.getZkMaxLatency().floatValue());
+            metrics.putMetric(ZOOKEEPER_METRIC_MIN_REQUEST_LATENCY,         cmdData.getZkMinLatency());
+            metrics.putMetric(ZOOKEEPER_METRIC_MAX_REQUEST_LATENCY,         cmdData.getZkMaxLatency());
             metrics.putMetric(ZOOKEEPER_METRIC_OUTSTANDING_REQUESTS,        cmdData.getZkOutstandingRequests().floatValue());
             metrics.putMetric(ZOOKEEPER_METRIC_NODE_COUNT,                  cmdData.getZkZnodeCount().floatValue());
             metrics.putMetric(ZOOKEEPER_METRIC_WATCH_COUNT,                 cmdData.getZkWatchCount().floatValue());


### PR DESCRIPTION
1.zk_min_latency、zk_max_latency指标数据类型变更为float
2.使用ConvertUtil.string2Float()方法进行string到float到类型转换