### PR TITLE
[Bugfix]修复新接入的集群，Controller-Host不显示的问题(#927)

### DIFF
--- a/km-core/src/main/java/com/xiaojukeji/know/streaming/km/core/flusher/zk/handler/ControllerNodeChangeHandler.java
+++ b/km-core/src/main/java/com/xiaojukeji/know/streaming/km/core/flusher/zk/handler/ControllerNodeChangeHandler.java
@@ -2,6 +2,7 @@ package com.xiaojukeji.know.streaming.km.core.flusher.zk.handler;
 
 import com.didiglobal.logi.log.ILog;
 import com.didiglobal.logi.log.LogFactory;
+import com.xiaojukeji.know.streaming.km.common.bean.entity.broker.Broker;
 import com.xiaojukeji.know.streaming.km.common.bean.entity.kafkacontroller.KafkaController;
 import com.xiaojukeji.know.streaming.km.common.bean.po.changerecord.KafkaChangeRecordPO;
 import com.xiaojukeji.know.streaming.km.common.constant.Constant;
@@ -100,7 +101,9 @@ public class ControllerNodeChangeHandler extends AbstractZKHandler implements ZN
             if (kafkaController == null) {
                 kafkaControllerService.setNoKafkaController(clusterPhyId, triggerTime);
             } else {
-                kafkaControllerService.insertAndIgnoreDuplicateException(kafkaController);
+                Broker broker = kafkaZKDAO.getBrokerMetadata(clusterPhyId, kafkaController.getBrokerId());
+
+                kafkaControllerService.insertAndIgnoreDuplicateException(kafkaController, broker != null? broker.getHost(): "", broker != null? broker.getRack(): "");
             }
         } catch (Exception e) {
             log.error("method=updateDBData||clusterPhyId={}||errMsg=exception", clusterPhyId, e);

--- a/km-core/src/main/java/com/xiaojukeji/know/streaming/km/core/service/kafkacontroller/KafkaControllerService.java
+++ b/km-core/src/main/java/com/xiaojukeji/know/streaming/km/core/service/kafkacontroller/KafkaControllerService.java
@@ -12,7 +12,7 @@ import java.util.Map;
 public interface KafkaControllerService {
     Result<KafkaController> getControllerFromKafka(ClusterPhy clusterPhy);
 
-    int insertAndIgnoreDuplicateException(KafkaController kafkaController);
+    int insertAndIgnoreDuplicateException(KafkaController kafkaController, String controllerHost, String controllerRack);
 
     int setNoKafkaController(Long clusterPhyId, Long triggerTime);
 


### PR DESCRIPTION
问题原因：
1、新接入的集群，DB中暂未存储Broker信息，因此在存储Controller至DB时，查询DB中的Broker会查询为空。

解决方式：
1、存储Controller至DB前，主动获取一次Broker的信息。