### PR TITLE
[Bugfix]ZK健康巡检日志不清晰导致问题难定位 #904

### DIFF
--- a/km-core/src/main/java/com/xiaojukeji/know/streaming/km/core/service/health/checker/zookeeper/HealthCheckZookeeperService.java
+++ b/km-core/src/main/java/com/xiaojukeji/know/streaming/km/core/service/health/checker/zookeeper/HealthCheckZookeeperService.java
@@ -122,7 +122,7 @@ public class HealthCheckZookeeperService extends AbstractHealthCheckService {
         );
         if (metricsResult.failed() || !metricsResult.hasData()) {
             log.error(
-                    "method=checkOutstandingRequests||clusterPhyId={}||param={}||config={}||result={}||errMsg=get metrics failed",clusterPhyId ,param, valueConfig, metricsResult
+                    "method=checkOutstandingRequests||clusterPhyId={}||param={}||config={}||result={}||errMsg=get metrics failed, may be collect failed or zk srvr command not in whitelist.",clusterPhyId ,param, valueConfig, metricsResult
             );
             return null;
         }
@@ -136,7 +136,7 @@ public class HealthCheckZookeeperService extends AbstractHealthCheckService {
 
         Float value = metricsResult.getData().getMetric(ZookeeperMetricVersionItems.ZOOKEEPER_METRIC_OUTSTANDING_REQUESTS);
         if(null == value){
-            log.error("method=checkOutstandingRequests||clusterPhyId={}|| errMsg=get OutstandingRequests metric failed, may be collect failed or zk mntr command not in whitelist.", clusterPhyId);
+            log.error("method=checkOutstandingRequests||clusterPhyId={}|| errMsg=get OutstandingRequests metric failed, may be collect failed or zk srvr command not in whitelist.", clusterPhyId);
             return null;
         }
         
@@ -169,7 +169,7 @@ public class HealthCheckZookeeperService extends AbstractHealthCheckService {
 
         if (metricsResult.failed() || !metricsResult.hasData()) {
             log.error(
-                    "method=checkWatchCount||param={}||config={}||result={}||errMsg=get metrics failed",
+                    "method=checkWatchCount||param={}||config={}||result={}||errMsg=get metrics failed, may be collect failed or zk mntr command not in whitelist.",
                     param, valueConfig, metricsResult
             );
             return null;
@@ -205,7 +205,7 @@ public class HealthCheckZookeeperService extends AbstractHealthCheckService {
 
         if (metricsResult.failed() || !metricsResult.hasData()) {
             log.error(
-                    "method=checkAliveConnections||param={}||config={}||result={}||errMsg=get metrics failed",
+                    "method=checkAliveConnections||param={}||config={}||result={}||errMsg=get metrics failed, may be collect failed or zk srvr command not in whitelist.",
                     param, valueConfig, metricsResult
             );
             return null;
@@ -241,7 +241,7 @@ public class HealthCheckZookeeperService extends AbstractHealthCheckService {
 
         if (metricsResult.failed() || !metricsResult.hasData()) {
             log.error(
-                    "method=checkApproximateDataSize||param={}||config={}||result={}||errMsg=get metrics failed",
+                    "method=checkApproximateDataSize||param={}||config={}||result={}||errMsg=get metrics failed, may be collect failed or zk srvr command not in whitelist.",
                     param, valueConfig, metricsResult
             );
             return null;
@@ -277,7 +277,7 @@ public class HealthCheckZookeeperService extends AbstractHealthCheckService {
 
         if (metricsResult.failed() || !metricsResult.hasData()) {
             log.error(
-                    "method=checkSentRate||param={}||config={}||result={}||errMsg=get metrics failed",
+                    "method=checkSentRate||param={}||config={}||result={}||errMsg=get metrics failed, may be collect failed or zk srvr command not in whitelist.",
                     param, valueConfig, metricsResult
             );
             return null;


### PR DESCRIPTION
[Bugfix]ZK健康巡检日志不清晰导致问题难定位 #904


## 在健康巡检时，会出现空指针异常，出现的原因是ZK的四字命令获取指标失败导致指标为空，因此建议对日志进行优化。

