### PR TITLE
[Bugfix]leader重选时忽略ElectionNotNeededException异常，返回成功

### DIFF
--- a/km-core/src/main/java/com/xiaojukeji/know/streaming/km/core/service/partition/impl/OpPartitionServiceImpl.java
+++ b/km-core/src/main/java/com/xiaojukeji/know/streaming/km/core/service/partition/impl/OpPartitionServiceImpl.java
@@ -19,6 +19,7 @@ import org.apache.kafka.clients.admin.ElectLeadersOptions;
 import org.apache.kafka.clients.admin.ElectLeadersResult;
 import org.apache.kafka.common.ElectionType;
 import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.errors.ElectionNotNeededException;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import scala.jdk.javaapi.CollectionConverters;
@@ -108,12 +109,17 @@ public class OpPartitionServiceImpl extends BaseKafkaVersionControlService imple
 
             return Result.buildSuc();
         } catch (Exception e) {
+            if(e.getCause() instanceof ElectionNotNeededException) {
+                // ignore ElectionNotNeededException
+                return Result.buildSuc();
+            }
+
             LOGGER.error(
                     "method=preferredReplicaElectionByKafkaClient||clusterPhyId={}||errMsg=exception",
                     partitionParam.getClusterPhyId(), e
             );
 
-            return Result.buildFromRSAndMsg(ResultStatus.ZK_OPERATE_FAILED, e.getMessage());
+            return Result.buildFromRSAndMsg(ResultStatus.KAFKA_OPERATE_FAILED, e.getMessage());
         }
     }
 }


### PR DESCRIPTION
请不要在没有先创建Issue的情况下创建Pull Request。

## 变更的目的是什么
fix issue [987](https://github.com/didi/KnowStreaming/issues/987)

## 简短的更新日志

更新任务状态时要执行leader重选，一部分leader重选失败，导致集群均衡任务状态无法更新。
修复方法：leader重选报错ElectionNotNeededException: Leader election not needed for topic partition时，可以认为无需执行重选，直接忽略该异常即可。

## 验证这一变化



请遵循此清单，以帮助我们快速轻松地整合您的贡献：

* [x] 一个 PR（Pull Request的简写）只解决一个问题，禁止一个 PR 解决多个问题；
* [x] 确保 PR 有对应的 Issue（通常在您开始处理之前创建），除非是书写错误之类的琐碎更改不需要 Issue ；
* [x] 格式化 PR 及 Commit-Log 的标题及内容，例如 #861 。PS：Commit-Log 需要在 Git Commit 代码时进行填写，在 GitHub 上修改不了；
* [x] 编写足够详细的 PR 描述，以了解 PR 的作用、方式和原因；
* [x] 编写必要的单元测试来验证您的逻辑更正。如果提交了新功能或重大更改，请记住在 test 模块中添加 integration-test；
* [x] 确保编译通过，集成测试通过；

