### PR TITLE
fix(sec): upgrade org.springframework:spring-web to 6.0.0

### DIFF
--- a/km-rest/pom.xml
+++ b/km-rest/pom.xml
@@ -18,7 +18,7 @@
         <log4j2.version>2.16.0</log4j2.version>
 
         <springboot.version>2.3.7.RELEASE</springboot.version>
-        <spring.version>5.3.19</spring.version>
+        <spring.version>6.0.0</spring.version>
 
         <maven.test.skip>false</maven.test.skip>
     </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -36,7 +36,7 @@
         <caffeine.version>2.8.8</caffeine.version>
 
         <springboot.version>2.3.7.RELEASE</springboot.version>
-        <spring.version>5.3.19</spring.version>
+        <spring.version>6.0.0</spring.version>
         <tomcat.version>9.0.41</tomcat.version>
         <jackson-bom.version>2.13.5</jackson-bom.version>
 


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in org.springframework:spring-web 5.3.19
- [CVE-2016-1000027](https://www.oscs1024.com/hd/CVE-2016-1000027)


### What did I do？
Upgrade org.springframework:spring-web from 5.3.19 to 6.0.0 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS