### PR TITLE
fix(sec): upgrade org.springframework.boot:spring-boot-actuator-autoconfigure to 3.0.6

### DIFF
--- a/km-rest/pom.xml
+++ b/km-rest/pom.xml
@@ -17,7 +17,7 @@
         <failOnMissingWebXml>false</failOnMissingWebXml>
         <log4j2.version>2.16.0</log4j2.version>
 
-        <springboot.version>2.3.7.RELEASE</springboot.version>
+        <springboot.version>3.0.6</springboot.version>
         <spring.version>5.3.19</spring.version>
 
         <maven.test.skip>false</maven.test.skip>

--- a/pom.xml
+++ b/pom.xml
@@ -35,7 +35,7 @@
         <mybatis-plus.version>3.4.2</mybatis-plus.version>
         <caffeine.version>2.8.8</caffeine.version>
 
-        <springboot.version>2.3.7.RELEASE</springboot.version>
+        <springboot.version>3.0.6</springboot.version>
         <spring.version>5.3.19</spring.version>
         <tomcat.version>9.0.41</tomcat.version>
         <jackson-bom.version>2.13.5</jackson-bom.version>


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in org.springframework.boot:spring-boot-actuator-autoconfigure 2.3.7.RELEASE
- [CVE-2023-20873](https://www.oscs1024.com/hd/CVE-2023-20873)


### What did I do？
Upgrade org.springframework.boot:spring-boot-actuator-autoconfigure from 2.3.7.RELEASE to 3.0.6 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS