### PR TITLE
修复未配置jmx不停打印error日志问题#1011

### DIFF
--- a/km-common/src/main/java/com/xiaojukeji/know/streaming/km/common/jmx/JmxConnectorWrap.java
+++ b/km-common/src/main/java/com/xiaojukeji/know/streaming/km/common/jmx/JmxConnectorWrap.java
@@ -64,12 +64,16 @@ public class JmxConnectorWrap {
         this.atomicInteger = new AtomicInteger(this.jmxConfig.getMaxConn());
     }
 
-    public boolean checkJmxConnectionAndInitIfNeed() {
+    public boolean checkJmxConnectionNeed() {
+        return this.port != null && this.port > 0;
+    }
+
+    public boolean initJmxConnection() {
+        if (!this.checkJmxConnectionNeed()) {
+            return false;
+        }
         if (jmxConnector != null) {
             return true;
-        }
-        if (port == null || port == -1) {
-            return false;
         }
         return createJmxConnector();
     }
@@ -221,6 +225,6 @@ public class JmxConnectorWrap {
         this.close();
 
         // 重新创建
-        this.checkJmxConnectionAndInitIfNeed();
+        this.initJmxConnection();
     }
 }

--- a/km-persistence/src/main/java/com/xiaojukeji/know/streaming/km/persistence/connect/ConnectJMXClient.java
+++ b/km-persistence/src/main/java/com/xiaojukeji/know/streaming/km/persistence/connect/ConnectJMXClient.java
@@ -35,7 +35,14 @@ public class ConnectJMXClient extends AbstractConnectClusterChangeHandler {
     public JmxConnectorWrap getClientWithCheck(Long connectClusterId, String workerId) {
         JmxConnectorWrap jmxConnectorWrap = this.getClient(connectClusterId, workerId);
 
-        if (ValidateUtils.isNull(jmxConnectorWrap) || !jmxConnectorWrap.checkJmxConnectionAndInitIfNeed()) {
+        if (ValidateUtils.isNull(jmxConnectorWrap)) {
+            log.error("method=getClientWithCheck||connectClusterId={}||workerId={}||msg=get jmx connectorWrap failed!", connectClusterId, workerId);
+            return null;
+        }
+        if (!jmxConnectorWrap.checkJmxConnectionNeed()) {
+            return null;
+        }
+        if (!jmxConnectorWrap.initJmxConnection()) {
             log.error("method=getClientWithCheck||connectClusterId={}||workerId={}||msg=get jmx connector failed!", connectClusterId, workerId);
             return null;
         }

--- a/km-persistence/src/main/java/com/xiaojukeji/know/streaming/km/persistence/jmx/impl/JmxDAOImpl.java
+++ b/km-persistence/src/main/java/com/xiaojukeji/know/streaming/km/persistence/jmx/impl/JmxDAOImpl.java
@@ -27,7 +27,10 @@ public class JmxDAOImpl implements JmxDAO {
         JmxConnectorWrap jmxConnectorWrap = null;
         try {
             jmxConnectorWrap = new JmxConnectorWrap("clusterPhyId: " + clusterPhyId, null, jmxHost, jmxPort, jmxConfig);
-            if (!jmxConnectorWrap.checkJmxConnectionAndInitIfNeed()) {
+            if (!jmxConnectorWrap.checkJmxConnectionNeed()) {
+                return null;
+            }
+            if (!jmxConnectorWrap.initJmxConnection()) {
                 log.error(
                         "method=getJmxValue||clusterPhyId={}||jmxHost={}||jmxPort={}||jmxConfig={}||errMgs=create jmx client failed",
                         clusterPhyId, jmxHost, jmxPort, jmxConfig

--- a/km-persistence/src/main/java/com/xiaojukeji/know/streaming/km/persistence/kafka/KafkaJMXClient.java
+++ b/km-persistence/src/main/java/com/xiaojukeji/know/streaming/km/persistence/kafka/KafkaJMXClient.java
@@ -35,7 +35,14 @@ public class KafkaJMXClient extends AbstractClusterLoadedChangedHandler {
     public JmxConnectorWrap getClientWithCheck(Long clusterPhyId, Integer brokerId){
         JmxConnectorWrap jmxConnectorWrap = this.getClient(clusterPhyId, brokerId);
 
-        if (ValidateUtils.isNull(jmxConnectorWrap) || !jmxConnectorWrap.checkJmxConnectionAndInitIfNeed()) {
+        if (ValidateUtils.isNull(jmxConnectorWrap)) {
+            log.error("method=getClientWithCheck||clusterPhyId={}||brokerId={}||msg=get jmx connectorWrap failed!", clusterPhyId, brokerId);
+            return null;
+        }
+        if (!jmxConnectorWrap.checkJmxConnectionNeed()) {
+            return null;
+        }
+        if (!jmxConnectorWrap.initJmxConnection()) {
             log.error("method=getClientWithCheck||clusterPhyId={}||brokerId={}||msg=get jmx connector failed!", clusterPhyId, brokerId);
             return null;
         }


### PR DESCRIPTION
## 变更的目的是什么

在没有配置jmx或jmx端口<=0时不打印错误日志

## 简短的更新日志

把原代码中检查是否需要jmx和创建jmx connection的逻辑分开，先进行jmx端口检查，避免在不需要时打印错误日志

## 验证这一变化

未配置jmx时不再打印错误日志




