### PR TITLE
[Bugfix]修复Topic消息展示，offset为0不显示问题 (#996)

### DIFF
--- a/km-console/packages/layout-clusters-fe/src/pages/TopicDetail/config.tsx
+++ b/km-console/packages/layout-clusters-fe/src/pages/TopicDetail/config.tsx
@@ -81,7 +81,7 @@ export const getTopicMessagesColmns = () => {
       title: 'Offset',
       dataIndex: 'offset',
       key: 'offset',
-      render: (t: number) => (t ? t.toLocaleString() : '-'),
+      // render: (t: number) => (t ? t.toLocaleString() : '-'),
     },
     {
       title: 'Timestamp',


### PR DESCRIPTION
修复了Topic中Messages展示，offset为0不显示问题