### PR TITLE
日志输出增加支持MDC #1031

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -329,6 +329,14 @@
                 <scope>import</scope>
             </dependency>
             <!--testcontainers end-->
+
+            <!-- MDC -->
+            <dependency>
+                <groupId>net.logstash.logback</groupId>
+                <artifactId>logstash-logback-encoder</artifactId>
+                <version>7.1.1</version>
+            </dependency>
+            <!-- MDC end -->
         </dependencies>
     </dependencyManagement>
 </project>


### PR DESCRIPTION
## 变更的目的是什么

支持MDC，方便用户接入链路追踪系统也可以在logback.xml中json格式化日志。

## 简短的更新日志

pom.xml文件中引入logstash-logback-encoder.jar包

## 验证这一变化

`
        <encoder charset="utf-8" class="net.logstash.logback.encoder.LogstashEncoder">
            <includeCallerData>true</includeCallerData>
            <includeMdcKeyName>springAppName</includeMdcKeyName>
            <includeMdcKeyName>traceId</includeMdcKeyName>
            <includeMdcKeyName>spanId</includeMdcKeyName>
            <includeMdcKeyName>parentSpanId</includeMdcKeyName>
            <customFields>{"system": "know-streaming"}
            </customFields>
        </encoder>`
在logback-spring.xml中加入以上encoder后即可支持链路追踪功能。
jar包兼容性及功能已测试通过。

