### PR TITLE
[Bugfix]修复权限ACL管理中，消费组列表展示错误的问题(#991)

### DIFF
--- a/km-common/src/main/java/com/xiaojukeji/know/streaming/km/common/converter/GroupConverter.java
+++ b/km-common/src/main/java/com/xiaojukeji/know/streaming/km/common/converter/GroupConverter.java
@@ -4,6 +4,7 @@ import com.xiaojukeji.know.streaming.km.common.bean.entity.group.Group;
 import com.xiaojukeji.know.streaming.km.common.bean.entity.group.GroupTopicMember;
 import com.xiaojukeji.know.streaming.km.common.bean.po.group.GroupPO;
 import com.xiaojukeji.know.streaming.km.common.bean.vo.group.GroupOverviewVO;
+import com.xiaojukeji.know.streaming.km.common.bean.vo.metadata.GroupMetadataCombineExistVO;
 import com.xiaojukeji.know.streaming.km.common.enums.group.GroupStateEnum;
 import com.xiaojukeji.know.streaming.km.common.enums.group.GroupTypeEnum;
 import com.xiaojukeji.know.streaming.km.common.utils.ConvertUtil;
@@ -61,4 +62,17 @@ public class GroupConverter {
         po.setUpdateTime(new Date());
         return po;
     }
+
+    public static GroupMetadataCombineExistVO convert2GroupMetadataCombineExistVO(String groupName, Group group) {
+        GroupMetadataCombineExistVO vo = new GroupMetadataCombineExistVO();
+        vo.setGroupName(groupName);
+        if (group == null) {
+            vo.setExist(false);
+            return vo;
+        }
+        vo.setExist(true);
+        vo.setClusterPhyId(group.getClusterPhyId());
+        return vo;
+    }
+
 }

--- a/km-console/packages/layout-clusters-fe/src/api/index.ts
+++ b/km-console/packages/layout-clusters-fe/src/api/index.ts
@@ -94,6 +94,9 @@ const api = {
   getTopicGroupPartitionsHistory: (clusterPhyId: number, groupName: string) =>
     getApi(`/clusters/${clusterPhyId}/groups/${groupName}/partitions`),
   resetGroupOffset: () => getApi('/group-offsets'),
+  getGroupMetadata: (clusterPhyId: number, groupName: string) =>
+    getApi(`/clusters/${clusterPhyId}/groups/${groupName}/metadata-combine-exist`),
+  getGroupOverview: (clusterPhyId: number) => getApi(`/clusters/${clusterPhyId}/groups-basic`),
 
   // topics列表
   getTopicsList: (clusterPhyId: number) => getApi(`/clusters/${clusterPhyId}/topics-overview`),

--- a/km-console/packages/layout-clusters-fe/src/pages/SecurityACLs/EditDrawer.tsx
+++ b/km-console/packages/layout-clusters-fe/src/pages/SecurityACLs/EditDrawer.tsx
@@ -85,6 +85,7 @@ const AddDrawer = forwardRef((_, ref) => {
     return;
   });
   const [topicMetaData, setTopicMetaData] = React.useState([]);
+  const [groupMetaData, setGroupMetaData] = React.useState([]);
 
   // 获取 Topic 元信息
   const getTopicMetaData = (newValue: any) => {
@@ -99,6 +100,21 @@ const AddDrawer = forwardRef((_, ref) => {
         };
       });
       setTopicMetaData(topics);
+    });
+  };
+
+  // 获取 Group 元信息
+  const getGroupMetaData = () => {
+    Utils.request(api.getGroupOverview(+clusterId), {
+      method: 'GET',
+    }).then((res: UsersProps[]) => {
+      const groups = (res || []).map((item: any) => {
+        return {
+          label: item.groupName,
+          value: item.groupName,
+        };
+      });
+      setGroupMetaData(groups);
     });
   };
 
@@ -209,6 +225,7 @@ const AddDrawer = forwardRef((_, ref) => {
   useEffect(() => {
     getKafkaUserList();
     getTopicMetaData('');
+    getGroupMetaData();
   }, []);
 
   return (
@@ -308,6 +325,10 @@ const AddDrawer = forwardRef((_, ref) => {
                                   return Utils.request(api.getTopicMetadata(clusterId as any, value)).then((res: any) => {
                                     return res?.exist ? Promise.resolve() : Promise.reject('该 Topic 不存在');
                                   });
+                                }else if (type === 'group' && getFieldValue(`${type}PatternType`) === ACL_PATTERN_TYPE['Literal']){
+                                  return Utils.request(api.getGroupMetadata(clusterId as any, value)).then((res: any) => {
+                                    return res?.exist ? Promise.resolve() : Promise.reject('该 Group 不存在');
+                                  });
                                 }
                                 return Promise.resolve();
                               },
@@ -321,7 +342,7 @@ const AddDrawer = forwardRef((_, ref) => {
                               }
                               return false;
                             }}
-                            options={topicMetaData}
+                            options={type === 'topic' ? topicMetaData : type === 'group' ? groupMetaData : []}
                             placeholder={`请输入 ${type}Name`}
                           />
                         </Form.Item>

--- a/km-rest/src/main/java/com/xiaojukeji/know/streaming/km/rest/api/v3/group/GroupController.java
+++ b/km-rest/src/main/java/com/xiaojukeji/know/streaming/km/rest/api/v3/group/GroupController.java
@@ -4,6 +4,7 @@ import com.didiglobal.logi.security.util.HttpRequestUtil;
 import com.xiaojukeji.know.streaming.km.biz.group.GroupManager;
 import com.xiaojukeji.know.streaming.km.common.bean.dto.group.GroupOffsetResetDTO;
 import com.xiaojukeji.know.streaming.km.common.bean.dto.group.GroupTopicConsumedDTO;
+import com.xiaojukeji.know.streaming.km.common.bean.entity.group.Group;
 import com.xiaojukeji.know.streaming.km.common.bean.entity.result.PaginationResult;
 import com.xiaojukeji.know.streaming.km.common.bean.entity.result.Result;
 import com.xiaojukeji.know.streaming.km.common.bean.po.group.GroupMemberPO;
@@ -11,6 +12,7 @@ import com.xiaojukeji.know.streaming.km.common.bean.vo.group.GroupTopicConsumedD
 import com.xiaojukeji.know.streaming.km.common.bean.vo.metadata.GroupMetadataCombineExistVO;
 import com.xiaojukeji.know.streaming.km.common.constant.ApiPrefix;
 import com.xiaojukeji.know.streaming.km.common.constant.Constant;
+import com.xiaojukeji.know.streaming.km.common.converter.GroupConverter;
 import com.xiaojukeji.know.streaming.km.core.service.group.GroupService;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
@@ -62,4 +64,15 @@ public class GroupController {
 
         return Result.buildSuc(new GroupMetadataCombineExistVO(clusterPhyId, groupName, topicName, true));
     }
+
+    @ApiOperation(value = "Group元信息", notes = "主要判断是否存在信息")
+    @GetMapping(value = "clusters/{clusterPhyId}/groups/{groupName}/metadata-combine-exist")
+    @ResponseBody
+    public Result<GroupMetadataCombineExistVO> getGroupMetadataCombineExist(@PathVariable Long clusterPhyId,
+                                                                            @PathVariable String groupName) {
+        Group group = groupService.getGroupFromDB(clusterPhyId, groupName);
+        return Result.buildSuc(GroupConverter.convert2GroupMetadataCombineExistVO(groupName, group));
+    }
+
+
 }


### PR DESCRIPTION
修复权限ACL管理中，消费组列表展示错误的问题
代码修改后效果：
1.消费组列表里面展示的是Group列表
2.并像生产组一样判断Group是否存在


