### PR TITLE
[Bugfix]修复权限ACL管理中，消费组列表展示错误的问题(#991)

### DIFF
--- a/km-console/packages/layout-clusters-fe/src/api/index.ts
+++ b/km-console/packages/layout-clusters-fe/src/api/index.ts
@@ -94,6 +94,7 @@ const api = {
   getTopicGroupPartitionsHistory: (clusterPhyId: number, groupName: string) =>
     getApi(`/clusters/${clusterPhyId}/groups/${groupName}/partitions`),
   resetGroupOffset: () => getApi('/group-offsets'),
+  getGroupOverview: (clusterPhyId: number) => getApi(`/clusters/${clusterPhyId}/groups-overview`),
 
   // topics列表
   getTopicsList: (clusterPhyId: number) => getApi(`/clusters/${clusterPhyId}/topics-overview`),

--- a/km-console/packages/layout-clusters-fe/src/pages/SecurityACLs/EditDrawer.tsx
+++ b/km-console/packages/layout-clusters-fe/src/pages/SecurityACLs/EditDrawer.tsx
@@ -85,6 +85,7 @@ const AddDrawer = forwardRef((_, ref) => {
     return;
   });
   const [topicMetaData, setTopicMetaData] = React.useState([]);
+  const [groupMetaData, setGroupMetaData] = React.useState([]);
 
   // 获取 Topic 元信息
   const getTopicMetaData = (newValue: any) => {
@@ -99,6 +100,21 @@ const AddDrawer = forwardRef((_, ref) => {
         };
       });
       setTopicMetaData(topics);
+    });
+  };
+
+  // 获取 Group 元信息
+  const getGroupMetaData = () => {
+    Utils.request(api.getGroupOverview(+clusterId), {
+      method: 'GET',
+    }).then((res: any) => {
+      const groups = res?.bizData.map((item: any) => {
+        return {
+          label: item.name,
+          value: item.name,
+        };
+      });
+      setGroupMetaData(groups);
     });
   };
 
@@ -209,6 +225,7 @@ const AddDrawer = forwardRef((_, ref) => {
   useEffect(() => {
     getKafkaUserList();
     getTopicMetaData('');
+    getGroupMetaData();
   }, []);
 
   return (
@@ -321,7 +338,7 @@ const AddDrawer = forwardRef((_, ref) => {
                               }
                               return false;
                             }}
-                            options={topicMetaData}
+                            options={type === 'topic' ? topicMetaData : groupMetaData}
                             placeholder={`请输入 ${type}Name`}
                           />
                         </Form.Item>


### PR DESCRIPTION
请不要在没有先创建Issue的情况下创建Pull Request。

## 变更的目的是什么
修复权限ACL管理中，消费组列表展示错误的问题

## 简短的更新日志
1.消费组列表里面展示的是Group列表
2.并像生产组一样判断Group是否存在

## 验证这一变化
消费组：
![image](https://github.com/didi/KnowStreaming/assets/43955116/d2d59f44-2989-4268-9adc-ebae5aedafa2)
代码修改后效果图：
![image](https://github.com/didi/KnowStreaming/assets/43955116/f1092184-cff3-47d3-bf4c-ec5511239aa8)
![image](https://github.com/didi/KnowStreaming/assets/43955116/678a7f8f-8664-4f72-9791-93d45defe677)


请遵循此清单，以帮助我们快速轻松地整合您的贡献：

* [x] 一个 PR（Pull Request的简写）只解决一个问题，禁止一个 PR 解决多个问题；
* [x] 确保 PR 有对应的 Issue（通常在您开始处理之前创建），除非是书写错误之类的琐碎更改不需要 Issue ；
* [x] 格式化 PR 及 Commit-Log 的标题及内容，例如 #861 。PS：Commit-Log 需要在 Git Commit 代码时进行填写，在 GitHub 上修改不了；
* [x] 编写足够详细的 PR 描述，以了解 PR 的作用、方式和原因；
* [x] 编写必要的单元测试来验证您的逻辑更正。如果提交了新功能或重大更改，请记住在 test 模块中添加 integration-test；
* [x] 确保编译通过，集成测试通过；

