### PR TITLE
[Optimize]Topic-Messages页面前端增加按照Partition和Offset纬度的排序

### DIFF
--- a/km-common/src/main/java/com/xiaojukeji/know/streaming/km/common/bean/vo/topic/TopicRecordVO.java
+++ b/km-common/src/main/java/com/xiaojukeji/know/streaming/km/common/bean/vo/topic/TopicRecordVO.java
@@ -34,4 +34,7 @@ public class TopicRecordVO {
 
     @ApiModelProperty(value = "记录值", example = "测试Value测试Value测试Value测试Value")
     private String value;
+
+    @ApiModelProperty(value = "唯一键", example = "用于查询消息的唯一键")
+    private String index;
 }

--- a/km-common/src/main/java/com/xiaojukeji/know/streaming/km/common/converter/TopicVOConverter.java
+++ b/km-common/src/main/java/com/xiaojukeji/know/streaming/km/common/converter/TopicVOConverter.java
@@ -49,6 +49,7 @@ public class TopicVOConverter {
         vo.setKey(consumerRecord.key());
         vo.setValue(consumerRecord.value());
         vo.setHeaderList(new ArrayList<>());
+        vo.setIndex(consumerRecord.partition()+"-"+consumerRecord.offset());
         for (Header header : consumerRecord.headers().toArray()) {
             vo.getHeaderList().add(new RecordHeaderKS(header.key(), new String(header.value(), StandardCharsets.UTF_8)));
         }

--- a/km-console/packages/layout-clusters-fe/src/pages/TopicDetail/Messages.tsx
+++ b/km-console/packages/layout-clusters-fe/src/pages/TopicDetail/Messages.tsx
@@ -191,7 +191,7 @@ const TopicMessages = (props: any) => {
         showQueryForm={false}
         tableProps={{
           showHeader: false,
-          rowKey: 'offset',
+          rowKey: 'index',
           loading: loading,
           columns: getTopicMessagesColmns(),
           dataSource: data,

--- a/km-console/packages/layout-clusters-fe/src/pages/TopicDetail/config.tsx
+++ b/km-console/packages/layout-clusters-fe/src/pages/TopicDetail/config.tsx
@@ -76,11 +76,13 @@ export const getTopicMessagesColmns = () => {
       title: 'Partition',
       dataIndex: 'partitionId',
       key: 'partitionId',
+      sorter: true,
     },
     {
       title: 'Offset',
       dataIndex: 'offset',
       key: 'offset',
+      sorter: true,
       render: (t: number) => (t ? t.toLocaleString() : '-'),
     },
     {


### PR DESCRIPTION
请不要在没有先创建Issue的情况下创建Pull Request。

## 变更的目的是什么

Topic-Messages页面前端增加按照Partition和Offset纬度的排序

## 简短的更新日志
Topic-Messages页面前端增加按照Partition和Offset纬度的排序

## 验证这一变化

### 按Offset排序
![image](https://github.com/didi/KnowStreaming/assets/43955116/f54ef55a-429b-41ba-84f7-100dc636b11a)
### 按Partition排序
![image](https://github.com/didi/KnowStreaming/assets/43955116/bc1bb32c-5c3e-448a-a201-485c756ca417)


请遵循此清单，以帮助我们快速轻松地整合您的贡献：

* [x] 一个 PR（Pull Request的简写）只解决一个问题，禁止一个 PR 解决多个问题；
* [x] 确保 PR 有对应的 Issue（通常在您开始处理之前创建），除非是书写错误之类的琐碎更改不需要 Issue ；
* [x] 格式化 PR 及 Commit-Log 的标题及内容，例如 #861 。PS：Commit-Log 需要在 Git Commit 代码时进行填写，在 GitHub 上修改不了；
* [x] 编写足够详细的 PR 描述，以了解 PR 的作用、方式和原因；
* [x] 编写必要的单元测试来验证您的逻辑更正。如果提交了新功能或重大更改，请记住在 test 模块中添加 integration-test；
* [x] 确保编译通过，集成测试通过；

