### PR TITLE
[Bugfix] 修复配置ldap登录，并设置auth-user-registration: false的空指针异常

### DIFF
--- a/km-extends/km-account/src/main/java/com/xiaojukeji/know/streaming/km/account/login/ldap/LdapLoginServiceImpl.java
+++ b/km-extends/km-account/src/main/java/com/xiaojukeji/know/streaming/km/account/login/ldap/LdapLoginServiceImpl.java
@@ -80,8 +80,8 @@ public class LdapLoginServiceImpl implements LoginExtend {
 
             // user赋值
             user = userService.getUserByUserName(ldapAttrsInfo.getSAMAccountName());
-        } else {
-            // 不自动注册用户时，赋值默认id给临时用户
+        } else if (ValidateUtils.isNull(user)) {
+            // user为空，且不自动注册用户时，赋值默认id给临时用户
             user = new User();
             user.setId(Constant.INVALID_CODE);
         }

--- a/km-extends/km-account/src/main/java/com/xiaojukeji/know/streaming/km/account/login/ldap/LdapLoginServiceImpl.java
+++ b/km-extends/km-account/src/main/java/com/xiaojukeji/know/streaming/km/account/login/ldap/LdapLoginServiceImpl.java
@@ -16,8 +16,8 @@ import com.xiaojukeji.know.streaming.km.account.KmAccountConfig;
 import com.xiaojukeji.know.streaming.km.account.common.bizenum.LoginServiceNameEnum;
 import com.xiaojukeji.know.streaming.km.account.common.ldap.LdapPrincipal;
 import com.xiaojukeji.know.streaming.km.account.login.ldap.remote.LdapAuthentication;
+import com.xiaojukeji.know.streaming.km.common.constant.Constant;
 import com.xiaojukeji.know.streaming.km.common.utils.CommonUtils;
-import com.xiaojukeji.know.streaming.km.common.utils.ConvertUtil;
 import com.xiaojukeji.know.streaming.km.common.utils.ValidateUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -80,6 +80,10 @@ public class LdapLoginServiceImpl implements LoginExtend {
 
             // user赋值
             user = userService.getUserByUserName(ldapAttrsInfo.getSAMAccountName());
+        } else {
+            // 不自动注册用户时，赋值默认id给临时用户
+            user = new User();
+            user.setId(Constant.INVALID_CODE);
         }
 
         // 记录登录状态


### PR DESCRIPTION
configure LDAP authentication and set auth-user-registration: false, result in NPE(Null Pointer Exception) #1116

请不要在没有先创建Issue的情况下创建Pull Request。

## 变更的目的是什么

fix NPE issue #1116

## 简短的更新日志

![image](https://github.com/didi/KnowStreaming/assets/51365967/b6b6925f-d45b-4212-8c6c-645f7e5000f5)

## 验证这一变化

configure LDAP authentication and set auth-user-registration: false

请遵循此清单，以帮助我们快速轻松地整合您的贡献：

* [ ] 一个 PR（Pull Request的简写）只解决一个问题，禁止一个 PR 解决多个问题；
* [ ] 确保 PR 有对应的 Issue（通常在您开始处理之前创建），除非是书写错误之类的琐碎更改不需要 Issue ；
* [ ] 格式化 PR 及 Commit-Log 的标题及内容，例如 #861 。PS：Commit-Log 需要在 Git Commit 代码时进行填写，在 GitHub 上修改不了；
* [ ] 编写足够详细的 PR 描述，以了解 PR 的作用、方式和原因；
* [ ] 编写必要的单元测试来验证您的逻辑更正。如果提交了新功能或重大更改，请记住在 test 模块中添加 integration-test；
* [ ] 确保编译通过，集成测试通过；

