### PR TITLE
[Bugfix]修复Topic列表翻页到第2页时，搜索显示不出结果来的问题

### DIFF
--- a/km-console/packages/layout-clusters-fe/src/pages/TopicList/index.tsx
+++ b/km-console/packages/layout-clusters-fe/src/pages/TopicList/index.tsx
@@ -348,6 +348,7 @@ const AutoPage = (props: any) => {
                   type="icon-fangdajing"
                   onClick={(_) => {
                     setSearchKeywords(searchKeywordsInput);
+                    setPageIndex(1);
                   }}
                   style={{ fontSize: '16px' }}
                 />
@@ -356,6 +357,7 @@ const AutoPage = (props: any) => {
               value={searchKeywordsInput}
               onPressEnter={(_) => {
                 setSearchKeywords(searchKeywordsInput);
+                setPageIndex(1);
               }}
               onChange={(e) => {
                 setSearchKeywordsInput(e.target.value);


### PR DESCRIPTION
请不要在没有先创建Issue的情况下创建Pull Request。

## 变更的目的是什么

修复Topic列表翻页到第2页时，搜索显示不出结果来的问题

## 简短的更新日志

看了后端代码，是由于在第二页搜索的时候，附带了pageNo=2，导致后端截取结果出现问题。
所以在搜索时，将pageNo设置为1，可前端改可后端改，这里改前端。

## 验证这一变化
### 只要搜索，就将pageNo设置为1
![image](https://github.com/didi/KnowStreaming/assets/43955116/44e34809-f097-4979-9845-20958d86cf60)
### 搜索结果
![image](https://github.com/didi/KnowStreaming/assets/43955116/d67bcdf2-12de-4e4c-9dd2-7c1000afd805)



请遵循此清单，以帮助我们快速轻松地整合您的贡献：

* [x] 一个 PR（Pull Request的简写）只解决一个问题，禁止一个 PR 解决多个问题；
* [x] 确保 PR 有对应的 Issue（通常在您开始处理之前创建），除非是书写错误之类的琐碎更改不需要 Issue ；
* [x] 格式化 PR 及 Commit-Log 的标题及内容，例如 #861 。PS：Commit-Log 需要在 Git Commit 代码时进行填写，在 GitHub 上修改不了；
* [x] 编写足够详细的 PR 描述，以了解 PR 的作用、方式和原因；
* [x] 编写必要的单元测试来验证您的逻辑更正。如果提交了新功能或重大更改，请记住在 test 模块中添加 integration-test；
* [x] 确保编译通过，集成测试通过；

