### PR TITLE
[Feature] #1155 Consume just filter key or value, not both. 消费消息支持单独过滤key或者value.

### DIFF
--- a/km-console/packages/layout-clusters-fe/src/pages/TestingConsumer/Consume.tsx
+++ b/km-console/packages/layout-clusters-fe/src/pages/TestingConsumer/Consume.tsx
@@ -144,6 +144,8 @@ const ConsumeClientTest = () => {
             ...configInfo,
             needFilterKeyValue: changeValue === 1 || changeValue === 2,
             needFilterSize: changeValue === 3 || changeValue === 4 || changeValue === 5,
+            needFilterKey: changeValue === 6,
+            needFilterValue: changeValue === 7,
           });
           break;
       }

--- a/km-console/packages/layout-clusters-fe/src/pages/TestingConsumer/config.tsx
+++ b/km-console/packages/layout-clusters-fe/src/pages/TestingConsumer/config.tsx
@@ -39,6 +39,14 @@ export const filterList = [
     label: 'Under Size',
     value: 5,
   },
+  {
+      label: 'key_contains',
+      value: 6,
+  },
+  {
+      label: 'value_contains',
+      value: 7,
+  }
 ];
 
 export const untilList = [
@@ -324,10 +332,10 @@ export const getFormConfig = (topicMetaData: any, info = {} as any, partitionLis
       key: 'filterKey',
       label: 'Key',
       type: FormItemType.input,
-      invisible: !info?.needFilterKeyValue,
+      invisible: !info?.needFilterKeyValue && !info?.needFilterKey,
       rules: [
         {
-          required: info?.needFilterKeyValue,
+          required: info?.needFilterKeyValue || info?.needFilterKey,
           message: '请输入Key',
         },
       ],
@@ -336,10 +344,10 @@ export const getFormConfig = (topicMetaData: any, info = {} as any, partitionLis
       key: 'filterValue',
       label: 'Value',
       type: FormItemType.input,
-      invisible: !info?.needFilterKeyValue,
+      invisible: !info?.needFilterKeyValue && !info?.needFilterValue,
       rules: [
         {
-          required: info?.needFilterKeyValue,
+          required: info?.needFilterKeyValue || info?.needFilterValue,
           message: '请输入Value',
         },
       ],

--- a/km-console/packages/layout-clusters-fe/src/pages/TestingConsumer/config.tsx
+++ b/km-console/packages/layout-clusters-fe/src/pages/TestingConsumer/config.tsx
@@ -16,19 +16,19 @@ export const cardList = [
 
 export const filterList = [
   {
-    label: 'none',
+    label: 'None',
     value: 0,
   },
   {
-    label: 'contains',
+    label: 'Contains',
     value: 1,
   },
   {
-    label: 'does not contains',
+    label: 'Does Not Contains',
     value: 2,
   },
   {
-    label: 'equals',
+    label: 'Equals',
     value: 3,
   },
   {
@@ -40,11 +40,11 @@ export const filterList = [
     value: 5,
   },
   {
-      label: 'key_contains',
+      label: 'Key Contains',
       value: 6,
   },
   {
-      label: 'value_contains',
+      label: 'Value Contains',
       value: 7,
   }
 ];

--- a/km-enterprise/km-testing/src/main/java/com/xiaojukeji/know/streaming/km/testing/biz/impl/KafkaClientTestManagerImpl.java
+++ b/km-enterprise/km-testing/src/main/java/com/xiaojukeji/know/streaming/km/testing/biz/impl/KafkaClientTestManagerImpl.java
@@ -451,6 +451,18 @@ public class KafkaClientTestManagerImpl implements KafkaClientTestManager {
             return Result.buildFromRSAndMsg(ResultStatus.PARAM_ILLEGAL, "包含的方式过滤，必须有过滤的key或value");
         }
 
+        // key包含过滤
+        if (KafkaConsumerFilterEnum.KEY_CONTAINS.getCode().equals(filter.getFilterType())
+            && ValidateUtils.isBlank(filter.getFilterCompareKey())) {
+            return Result.buildFromRSAndMsg(ResultStatus.PARAM_ILLEGAL, "key包含的方式过滤，必须有过滤的key");
+        }
+
+        // value包含过滤
+        if (KafkaConsumerFilterEnum.VALUE_CONTAINS.getCode().equals(filter.getFilterType())
+            && ValidateUtils.isBlank(filter.getFilterCompareValue())) {
+            return Result.buildFromRSAndMsg(ResultStatus.PARAM_ILLEGAL, "value包含的方式过滤，必须有过滤的value");
+        }
+
         // 不包含过滤
         if (KafkaConsumerFilterEnum.NOT_CONTAINS.getCode().equals(filter.getFilterType())
                 && ValidateUtils.isBlank(filter.getFilterCompareKey()) && ValidateUtils.isBlank(filter.getFilterCompareValue())) {
@@ -547,6 +559,18 @@ public class KafkaClientTestManagerImpl implements KafkaClientTestManager {
         if (KafkaConsumerFilterEnum.CONTAINS.getCode().equals(filter.getFilterType())
                 && (!ValidateUtils.isBlank(filter.getFilterCompareKey()) && consumerRecord.key() != null && consumerRecord.key().toString().contains(filter.getFilterCompareKey()))
                 && (!ValidateUtils.isBlank(filter.getFilterCompareValue()) && consumerRecord.value() != null && consumerRecord.value().toString().contains(filter.getFilterCompareValue()))) {
+            return true;
+        }
+
+        // key包含过滤
+        if (KafkaConsumerFilterEnum.KEY_CONTAINS.getCode().equals(filter.getFilterType())
+            && (!ValidateUtils.isBlank(filter.getFilterCompareKey()) && consumerRecord.key() != null && consumerRecord.key().toString().contains(filter.getFilterCompareKey()))) {
+            return true;
+        }
+
+        // value包含过滤
+        if (KafkaConsumerFilterEnum.VALUE_CONTAINS.getCode().equals(filter.getFilterType())
+            && (!ValidateUtils.isBlank(filter.getFilterCompareValue()) && consumerRecord.value() != null && consumerRecord.value().toString().contains(filter.getFilterCompareValue()))) {
             return true;
         }
 

--- a/km-enterprise/km-testing/src/main/java/com/xiaojukeji/know/streaming/km/testing/common/bean/dto/KafkaConsumerFilterDTO.java
+++ b/km-enterprise/km-testing/src/main/java/com/xiaojukeji/know/streaming/km/testing/common/bean/dto/KafkaConsumerFilterDTO.java
@@ -19,7 +19,7 @@ public class KafkaConsumerFilterDTO extends BaseDTO {
     /**
      * @see KafkaConsumerFilterEnum
      */
-    @Range(min = 0, max = 5, message = "filterType最大和最小值必须在[0, 5]之间")
+    @Range(min = 0, max = 7, message = "filterType最大和最小值必须在[0, 7]之间")
     @ApiModelProperty(value = "开始消费位置的类型", example = "2")
     private Integer filterType;
 

--- a/km-enterprise/km-testing/src/main/java/com/xiaojukeji/know/streaming/km/testing/common/enums/KafkaConsumerFilterEnum.java
+++ b/km-enterprise/km-testing/src/main/java/com/xiaojukeji/know/streaming/km/testing/common/enums/KafkaConsumerFilterEnum.java
@@ -22,6 +22,10 @@ public enum KafkaConsumerFilterEnum {
 
     UNDER_SIZE(5, "size小于"),
 
+    KEY_CONTAINS(6, "key包含"),
+
+    VALUE_CONTAINS(7, "value包含"),
+
     ;
 
     private final Integer code;


### PR DESCRIPTION
请不要在没有先创建Issue的情况下创建Pull Request。
## 变更的目的是什么

close #1155

## 简短的更新日志

Consume just filter key or value, not both.
消费消息支持单独过滤key或者value。

## 验证这一变化

![image](https://github.com/didi/KnowStreaming/assets/51365967/65397b38-7a66-458c-a023-2f4d2d6a8872)

请遵循此清单，以帮助我们快速轻松地整合您的贡献：

* [x] 一个 PR（Pull Request的简写）只解决一个问题，禁止一个 PR 解决多个问题；
* [x] 确保 PR 有对应的 Issue（通常在您开始处理之前创建），除非是书写错误之类的琐碎更改不需要 Issue ；
* [ ] 格式化 PR 及 Commit-Log 的标题及内容，例如 #861 。PS：Commit-Log 需要在 Git Commit 代码时进行填写，在 GitHub 上修改不了；
* [x] 编写足够详细的 PR 描述，以了解 PR 的作用、方式和原因；
* [x] 编写必要的单元测试来验证您的逻辑更正。如果提交了新功能或重大更改，请记住在 test 模块中添加 integration-test；
* [x] 确保编译通过，集成测试通过；

