### PR TITLE
[Feature]集群均衡支持LogDir级别的Disk均衡

### DIFF
--- a/km-core/src/main/java/com/xiaojukeji/know/streaming/km/core/service/group/impl/GroupServiceImpl.java
+++ b/km-core/src/main/java/com/xiaojukeji/know/streaming/km/core/service/group/impl/GroupServiceImpl.java
@@ -156,7 +156,9 @@ public class GroupServiceImpl extends BaseKafkaVersionControlService implements 
             ListConsumerGroupOffsetsResult listConsumerGroupOffsetsResult = adminClient.listConsumerGroupOffsets(groupName);
             Map<TopicPartition, OffsetAndMetadata> offsetAndMetadataMap = listConsumerGroupOffsetsResult.partitionsToOffsetAndMetadata().get();
             for (Map.Entry<TopicPartition, OffsetAndMetadata> entry: offsetAndMetadataMap.entrySet()) {
-                offsetMap.put(entry.getKey(), entry.getValue().offset());
+                if(entry != null && entry.getValue() != null) {
+                    offsetMap.put(entry.getKey(), entry.getValue().offset());
+                }
             }
 
             return offsetMap;

--- a/km-core/src/main/java/com/xiaojukeji/know/streaming/km/core/service/partition/impl/OpPartitionServiceImpl.java
+++ b/km-core/src/main/java/com/xiaojukeji/know/streaming/km/core/service/partition/impl/OpPartitionServiceImpl.java
@@ -19,6 +19,7 @@ import org.apache.kafka.clients.admin.ElectLeadersOptions;
 import org.apache.kafka.clients.admin.ElectLeadersResult;
 import org.apache.kafka.common.ElectionType;
 import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.errors.ElectionNotNeededException;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import scala.jdk.javaapi.CollectionConverters;
@@ -108,12 +109,17 @@ public class OpPartitionServiceImpl extends BaseKafkaVersionControlService imple
 
             return Result.buildSuc();
         } catch (Exception e) {
+            if(e.getCause() instanceof ElectionNotNeededException) {
+                // ignore ElectionNotNeededException
+                return Result.buildSuc();
+            }
+
             LOGGER.error(
                     "method=preferredReplicaElectionByKafkaClient||clusterPhyId={}||errMsg=exception",
                     partitionParam.getClusterPhyId(), e
             );
 
-            return Result.buildFromRSAndMsg(ResultStatus.ZK_OPERATE_FAILED, e.getMessage());
+            return Result.buildFromRSAndMsg(ResultStatus.KAFKA_OPERATE_FAILED, e.getMessage());
         }
     }
 }

--- a/km-enterprise/km-rebalance/src/main/java/com/xiaojukeji/know/streaming/km/rebalance/algorithm/executor/common/BalanceTask.java
+++ b/km-enterprise/km-rebalance/src/main/java/com/xiaojukeji/know/streaming/km/rebalance/algorithm/executor/common/BalanceTask.java
@@ -7,6 +7,7 @@ public class BalanceTask {
     private int partition;
     //副本分配列表
     private List<Integer> replicas;
+    private List<String> logDirs;
 
     public String getTopic() {
         return topic;
@@ -32,12 +33,21 @@ public class BalanceTask {
         this.replicas = replicas;
     }
 
+    public List<String> getLogDirs() {
+        return logDirs;
+    }
+
+    public void setLogDirs(List<String> logDirs) {
+        this.logDirs = logDirs;
+    }
+
     @Override
     public String toString() {
         return "BalanceTask{" +
                 "topic='" + topic + '\'' +
                 ", partition=" + partition +
                 ", replicas=" + replicas +
+                ", logDirs=" + logDirs +
                 '}';
     }
 }

--- a/km-enterprise/km-rebalance/src/main/java/com/xiaojukeji/know/streaming/km/rebalance/algorithm/executor/common/OptimizerResult.java
+++ b/km-enterprise/km-rebalance/src/main/java/com/xiaojukeji/know/streaming/km/rebalance/algorithm/executor/common/OptimizerResult.java
@@ -120,6 +120,8 @@ public class OptimizerResult {
             task.setPartition(proposal.tp().partition());
             List<Integer> replicas = proposal.newReplicas().stream().map(ReplicaPlacementInfo::brokerId).collect(Collectors.toList());
             task.setReplicas(replicas);
+            List<String> logDirs = proposal.newReplicas().stream().map(ReplicaPlacementInfo::logdir).collect(Collectors.toList());
+            task.setLogDirs(logDirs);
             balanceTasks.add(task);
         });
         return balanceTasks;

--- a/km-enterprise/km-rebalance/src/main/java/com/xiaojukeji/know/streaming/km/rebalance/algorithm/metric/elasticsearch/ElasticsearchMetricStore.java
+++ b/km-enterprise/km-rebalance/src/main/java/com/xiaojukeji/know/streaming/km/rebalance/algorithm/metric/elasticsearch/ElasticsearchMetricStore.java
@@ -50,7 +50,7 @@ public class ElasticsearchMetricStore implements MetricStore {
             String metricsQueryJson = IOUtils.resourceToString("/MetricsQuery.json", StandardCharsets.UTF_8);
             metricsQueryJson = metricsQueryJson.replaceAll("<var_before_time>", Integer.toString(beforeSeconds))
                     .replaceAll("<var_cluster_name>", clusterName);
-            try (RestClient restClient = RestClient.builder(toHttpHosts(this.hosts)).build()) {
+            try (RestClient restClient = RestClient.builder(toHttpHosts(this.hosts)).setMaxRetryTimeoutMillis(60000).build()) {
                 Request request = new Request(
                         "GET",
                         "/" + indices(beforeSeconds) + "/_search");

--- a/km-enterprise/km-rebalance/src/main/java/com/xiaojukeji/know/streaming/km/rebalance/algorithm/model/LogDir.java
+++ b/km-enterprise/km-rebalance/src/main/java/com/xiaojukeji/know/streaming/km/rebalance/algorithm/model/LogDir.java
@@ -1,0 +1,137 @@
+package com.xiaojukeji.know.streaming.km.rebalance.algorithm.model;
+
+import org.apache.kafka.common.TopicPartition;
+
+import java.util.*;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
+
+public class LogDir implements Comparable<LogDir>{
+
+    private final String name;
+    private final Broker broker;
+    private final Set<Replica> replicas;
+    private final Map<TopicPartition, Replica> topicPartitionReplicas;
+    private final Load load;
+    private final Capacity capacity;
+
+
+    public LogDir(String name, Broker broker, Capacity capacity) {
+        this.name = name;
+        this.broker = broker;
+        this.replicas = new HashSet<>();
+        this.load = new Load();
+        this.capacity = capacity;
+        this.topicPartitionReplicas = new HashMap<>();
+    }
+
+    public void addReplica(Replica replica) {
+        if (this.replicas.contains(replica)) {
+            throw new IllegalStateException(String.format("Broker %d logDir %s already has replica %s", this.broker.id(), this.name,
+                    replica.topicPartition()));
+        }
+        this.replicas.add(replica);
+        this.topicPartitionReplicas.put(replica.topicPartition(), replica);
+        this.load.addLoad(replica.load());
+    }
+
+    Replica removeReplica(TopicPartition topicPartition) {
+        Replica replica = this.topicPartitionReplicas.get(topicPartition);
+        if(replica == null) {
+            return replica;
+        }
+        this.replicas.remove(replica);
+        this.topicPartitionReplicas.remove(topicPartition);
+        this.load.subtractLoad(replica.load());
+        return replica;
+    }
+
+    public Set<Replica> replicas() {
+        return Collections.unmodifiableSet(this.replicas);
+    }
+
+    public String name() {
+        return this.name;
+    }
+
+    public Broker broker() {
+        return this.broker;
+    }
+
+    public Load load() {
+        return this.load;
+    }
+
+    public Capacity capacity() {
+        return this.capacity;
+    }
+
+    public double utilizationFor(Resource resource) {
+        return this.load.loadFor(resource) / this.capacity.capacityFor(resource);
+    }
+
+
+    public double expectedUtilizationAfterAdd(Resource resource, Load loadToChange) {
+        return (this.load.loadFor(resource) + ((loadToChange == null) ? 0 : loadToChange.loadFor(resource)))
+                / this.capacity.capacityFor(resource);
+    }
+
+
+    public double expectedUtilizationAfterRemove(Resource resource, Load loadToChange) {
+        return (this.load.loadFor(resource) - ((loadToChange == null) ? 0 : loadToChange.loadFor(resource)))
+                / this.capacity.capacityFor(resource);
+    }
+
+
+    public SortedSet<Replica> sortedReplicasFor(Predicate<? super Replica> filter, Resource resource, boolean reverse) {
+        Comparator<Replica> comparator =
+                Comparator.<Replica>comparingDouble(r -> r.load().loadFor(resource))
+                        .thenComparingInt(Replica::hashCode);
+        if (reverse)
+            comparator = comparator.reversed();
+        SortedSet<Replica> sortedReplicas = new TreeSet<>(comparator);
+        if (filter == null) {
+            sortedReplicas.addAll(this.replicas);
+        } else {
+            sortedReplicas.addAll(this.replicas.stream()
+                    .filter(filter).collect(Collectors.toList()));
+        }
+
+        return sortedReplicas;
+    }
+
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        LogDir logDir = (LogDir) o;
+        return broker.equals(logDir.broker) && name.equals(logDir.name);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(name, broker.id());
+    }
+
+    @Override
+    public int compareTo(LogDir o) {
+        int rst = Integer.compare(broker.id(), o.broker.id());
+        if(rst != 0) {
+            return rst;
+        } else {
+            return name.compareTo(o.name());
+        }
+    }
+
+    @Override
+    public String toString() {
+        return "LogDir{" +
+                "name=" + name +
+                ", broker='" + broker + '\'' +
+                ", replicas=" + replicas +
+                ", load=" + load +
+                ", capacity=" + capacity +
+                '}';
+    }
+}

--- a/km-enterprise/km-rebalance/src/main/java/com/xiaojukeji/know/streaming/km/rebalance/algorithm/model/Replica.java
+++ b/km-enterprise/km-rebalance/src/main/java/com/xiaojukeji/know/streaming/km/rebalance/algorithm/model/Replica.java
@@ -13,22 +13,24 @@ public class Replica {
     private final Replica original;
     private final TopicPartition topicPartition;
     private Broker broker;
+    private String logDir;
     private boolean isLeader;
     private boolean isOffline;
 
-    public Replica(Broker broker, TopicPartition topicPartition, boolean isLeader, boolean isOffline) {
-        this(broker, topicPartition, isLeader, isOffline, false);
+    public Replica(Broker broker, String logDir, TopicPartition topicPartition, boolean isLeader, boolean isOffline) {
+        this(broker, logDir, topicPartition, isLeader, isOffline, false);
     }
 
-    private Replica(Broker broker, TopicPartition topicPartition, boolean isLeader, boolean isOffline, boolean isOriginal) {
+    private Replica(Broker broker, String logDir, TopicPartition topicPartition, boolean isLeader, boolean isOffline, boolean isOriginal) {
         if (isOriginal) {
             this.original = null;
         } else {
-            this.original = new Replica(broker, topicPartition, isLeader, isOffline, true);
+            this.original = new Replica(broker, logDir, topicPartition, isLeader, isOffline, true);
         }
         this.load = new Load();
         this.topicPartition = topicPartition;
         this.broker = broker;
+        this.logDir = logDir;
         this.isLeader = isLeader;
         this.isOffline = isOffline;
     }
@@ -48,6 +50,14 @@ public class Replica {
     public void setBroker(Broker broker) {
         checkOriginal();
         this.broker = broker;
+    }
+
+    public String logDir() {
+        return logDir;
+    }
+
+    public void setLogDir(String logDir) {
+        this.logDir = logDir;
     }
 
     public boolean isLeader() {

--- a/km-enterprise/km-rebalance/src/main/java/com/xiaojukeji/know/streaming/km/rebalance/algorithm/optimizer/AnalyzerUtils.java
+++ b/km-enterprise/km-rebalance/src/main/java/com/xiaojukeji/know/streaming/km/rebalance/algorithm/optimizer/AnalyzerUtils.java
@@ -7,6 +7,8 @@ import com.xiaojukeji.know.streaming.km.rebalance.algorithm.model.Resource;
 import com.xiaojukeji.know.streaming.km.rebalance.algorithm.optimizer.goals.Goal;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.kafka.common.TopicPartition;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.*;
 import java.util.stream.Collectors;
@@ -14,7 +16,7 @@ import java.util.stream.Collectors;
 import static com.xiaojukeji.know.streaming.km.rebalance.algorithm.optimizer.ActionAcceptance.ACCEPT;
 
 public class AnalyzerUtils {
-
+    private static final Logger logger = LoggerFactory.getLogger(AnalyzerUtils.class);
     public static Set<String> getSplitTopics(String value) {
         if (StringUtils.isBlank(value)) {
             return new HashSet<>();
@@ -44,8 +46,12 @@ public class AnalyzerUtils {
             List<ReplicaPlacementInfo> initialReplicas = entry.getValue();
             List<ReplicaPlacementInfo> finalReplicas = finalReplicaDistribution.get(tp);
             Replica finalLeader = optimizedClusterModel.partition(tp);
-            ReplicaPlacementInfo finalLeaderPlacementInfo = new ReplicaPlacementInfo(finalLeader.broker().id(), "");
+            ReplicaPlacementInfo finalLeaderPlacementInfo = new ReplicaPlacementInfo(finalLeader.broker().id(), finalLeader.logDir());
             if (finalReplicas.equals(initialReplicas) && initialLeaderDistribution.get(tp).equals(finalLeaderPlacementInfo)) {
+                continue;
+            }
+            if(!balanceCheck(initialReplicas, finalReplicas)) {
+                logger.warn("illegal balance, topicPartition {}, before {}, after {}", tp, initialReplicas, finalReplicas);
                 continue;
             }
             if (!finalLeaderPlacementInfo.equals(finalReplicas.get(0))) {
@@ -57,6 +63,26 @@ public class AnalyzerUtils {
             diff.add(new ExecutionProposal(tp, partitionSize, initialLeaderDistribution.get(tp), initialReplicas, finalReplicas));
         }
         return diff;
+    }
+
+
+    /**
+     * 检查是否会出现相同broker不同logDir之间迁移的情况，此情况会触发kafka bug:https://issues.apache.org/jira/browse/KAFKA-9087
+     * @param beforeReplicaPlacementInfos
+     * @param afterReplicaPlacementInfos
+     * @return
+     */
+    private static boolean balanceCheck(List<ReplicaPlacementInfo> beforeReplicaPlacementInfos, List<ReplicaPlacementInfo> afterReplicaPlacementInfos) {
+        for(ReplicaPlacementInfo beforePlacement : beforeReplicaPlacementInfos) {
+            for(ReplicaPlacementInfo afterPlacement : afterReplicaPlacementInfos) {
+                if(beforePlacement.brokerId() == afterPlacement.brokerId()
+                        && !"".equals(beforePlacement.logdir())
+                        && !beforePlacement.logdir().equals(afterPlacement.logdir())) {
+                    return false;
+                }
+            }
+        }
+        return true;
     }
 
     public static ActionAcceptance isProposalAcceptableForOptimizedGoals(Set<Goal> optimizedGoals,

--- a/km-enterprise/km-rebalance/src/main/java/com/xiaojukeji/know/streaming/km/rebalance/algorithm/optimizer/BalancingAction.java
+++ b/km-enterprise/km-rebalance/src/main/java/com/xiaojukeji/know/streaming/km/rebalance/algorithm/optimizer/BalancingAction.java
@@ -5,7 +5,9 @@ import org.apache.kafka.common.TopicPartition;
 public class BalancingAction {
     private final TopicPartition _tp;
     private final Integer _sourceBrokerId;
+    private final String _sourceLogDir;
     private final Integer _destinationBrokerId;
+    private final String _destinationLogDir;
     private final ActionType _actionType;
 
     public BalancingAction(TopicPartition tp,
@@ -14,7 +16,23 @@ public class BalancingAction {
                            ActionType actionType) {
         _tp = tp;
         _sourceBrokerId = sourceBrokerId;
+        _sourceLogDir = "any";
         _destinationBrokerId = destinationBrokerId;
+        _destinationLogDir = "any";
+        _actionType = actionType;
+    }
+
+    public BalancingAction(TopicPartition tp,
+                           Integer sourceBrokerId,
+                           String sourceLogDir,
+                           Integer destinationBrokerId,
+                           String destinationLogDir,
+                           ActionType actionType) {
+        _tp = tp;
+        _sourceBrokerId = sourceBrokerId;
+        _sourceLogDir = sourceLogDir;
+        _destinationBrokerId = destinationBrokerId;
+        _destinationLogDir = destinationLogDir;
         _actionType = actionType;
     }
 
@@ -22,8 +40,16 @@ public class BalancingAction {
         return _sourceBrokerId;
     }
 
+    public String sourceLogDir() {
+        return _sourceLogDir;
+    }
+
     public Integer destinationBrokerId() {
         return _destinationBrokerId;
+    }
+
+    public String destinationLogDir() {
+        return _destinationLogDir;
     }
 
     public ActionType balancingAction() {

--- a/km-enterprise/km-rebalance/src/main/java/com/xiaojukeji/know/streaming/km/rebalance/algorithm/optimizer/goals/ResourceDistributionGoal.java
+++ b/km-enterprise/km-rebalance/src/main/java/com/xiaojukeji/know/streaming/km/rebalance/algorithm/optimizer/goals/ResourceDistributionGoal.java
@@ -8,16 +8,13 @@ import com.xiaojukeji.know.streaming.km.rebalance.algorithm.optimizer.Optimizati
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.Collections;
-import java.util.Iterator;
-import java.util.Set;
-import java.util.SortedSet;
+import java.util.*;
 
 /**
  * @author leewei
  * @date 2022/5/20
  */
-public abstract class ResourceDistributionGoal extends AbstractGoal {
+public abstract class ResourceDistributionGoal extends AbstractLogDirGoal {
     private static final Logger logger = LoggerFactory.getLogger(ResourceDistributionGoal.class);
     private double balanceUpperThreshold;
     private double balanceLowerThreshold;
@@ -35,66 +32,70 @@ public abstract class ResourceDistributionGoal extends AbstractGoal {
                                       ClusterModel clusterModel,
                                       Set<Goal> optimizedGoals,
                                       OptimizationOptions optimizationOptions) {
-        double utilization = broker.utilizationFor(resource());
+        for(LogDir logDir : broker.logDirs().values()) {
+            double utilization = logDir.utilizationFor(resource());
 
-        boolean requireLessLoad = utilization > this.balanceUpperThreshold;
-        boolean requireMoreLoad = utilization < this.balanceLowerThreshold;
-        if (!requireMoreLoad && !requireLessLoad) {
-            return;
-        }
+            boolean requireLessLoad = utilization > this.balanceUpperThreshold;
+            boolean requireMoreLoad = utilization < this.balanceLowerThreshold;
+            if (!requireMoreLoad && !requireLessLoad) {
+                return;
+            }
 
-        // First try leadership movement
-        if (resource() == Resource.NW_OUT || resource() == Resource.CPU) {
-            if (requireLessLoad && rebalanceByMovingLoadOut(broker, clusterModel, optimizedGoals,
-                    ActionType.LEADERSHIP_MOVEMENT, optimizationOptions)) {
-                logger.debug("Successfully balanced {} for broker {} by moving out leaders.", resource(), broker.id());
-                requireLessLoad = false;
+            // First try leadership movement
+            if (resource() == Resource.NW_OUT || resource() == Resource.CPU) {
+                if (requireLessLoad && rebalanceByMovingLoadOut(logDir, clusterModel, optimizedGoals,
+                        ActionType.LEADERSHIP_MOVEMENT, optimizationOptions)) {
+                    logger.debug("Successfully balanced {} for broker {} logDir {} by moving out leaders.", resource(), broker.id(), logDir.name());
+                    requireLessLoad = false;
+                }
+                if (requireMoreLoad && rebalanceByMovingLoadIn(logDir, clusterModel, optimizedGoals,
+                        ActionType.LEADERSHIP_MOVEMENT, optimizationOptions)) {
+                    logger.debug("Successfully balanced {} for broker {} logDir {} by moving in leaders.", resource(), broker.id(), logDir.name());
+                    requireMoreLoad = false;
+                }
             }
-            if (requireMoreLoad && rebalanceByMovingLoadIn(broker, clusterModel, optimizedGoals,
-                    ActionType.LEADERSHIP_MOVEMENT, optimizationOptions)) {
-                logger.debug("Successfully balanced {} for broker {} by moving in leaders.", resource(), broker.id());
-                requireMoreLoad = false;
-            }
-        }
 
-        boolean balanced = true;
-        if (requireLessLoad) {
-            if (!rebalanceByMovingLoadOut(broker, clusterModel, optimizedGoals,
-                    ActionType.REPLICA_MOVEMENT, optimizationOptions)) {
-                balanced = rebalanceBySwappingLoadOut(broker, clusterModel, optimizedGoals, optimizationOptions);
+            boolean balanced = true;
+            if (requireLessLoad) {
+                if (!rebalanceByMovingLoadOut(logDir, clusterModel, optimizedGoals,
+                        ActionType.REPLICA_MOVEMENT, optimizationOptions)) {
+                    balanced = rebalanceBySwappingLoadOut(logDir, clusterModel, optimizedGoals, optimizationOptions);
+                }
+            } else if (requireMoreLoad) {
+                if (!rebalanceByMovingLoadIn(logDir, clusterModel, optimizedGoals,
+                        ActionType.REPLICA_MOVEMENT, optimizationOptions)) {
+                    balanced = rebalanceBySwappingLoadIn(logDir, clusterModel, optimizedGoals, optimizationOptions);
+                }
             }
-        } else if (requireMoreLoad) {
-            if (!rebalanceByMovingLoadIn(broker, clusterModel, optimizedGoals,
-                    ActionType.REPLICA_MOVEMENT, optimizationOptions)) {
-                balanced = rebalanceBySwappingLoadIn(broker, clusterModel, optimizedGoals, optimizationOptions);
+            if (balanced) {
+                logger.debug("Successfully balanced {} for broker {} logDir {} by moving leaders and replicas.", resource(), broker.id(), logDir.name());
+            } else {
+                logger.debug("Balance {} for broker {} logDir {} failed.", resource(), broker.id(), logDir.name());
             }
-        }
-        if (balanced) {
-            logger.debug("Successfully balanced {} for broker {} by moving leaders and replicas.", resource(), broker.id());
         }
     }
 
-    private boolean rebalanceByMovingLoadOut(Broker broker,
+    private boolean rebalanceByMovingLoadOut(LogDir logDir,
                                              ClusterModel clusterModel,
                                              Set<Goal> optimizedGoals,
                                              ActionType actionType,
                                              OptimizationOptions optimizationOptions) {
 
-        SortedSet<Broker> candidateBrokers = sortedCandidateBrokersUnderThreshold(clusterModel, this.balanceUpperThreshold, optimizationOptions, broker, false);
-        SortedSet<Replica> replicasToMove = sortedCandidateReplicas(broker, actionType, optimizationOptions, true);
+        SortedSet<LogDir> candidateLogDirs = sortedCandidateLogDirsUnderThreshold(clusterModel, this.balanceUpperThreshold, optimizationOptions, logDir.broker(), false);
+        SortedSet<Replica> replicasToMove = sortedCandidateReplicas(logDir, actionType, optimizationOptions, true);
 
         for (Replica replica : replicasToMove) {
-            Broker acceptedBroker = maybeApplyBalancingAction(clusterModel, replica, candidateBrokers, actionType, optimizedGoals, optimizationOptions);
+            LogDir acceptedLogDir = maybeApplyBalancingAction(clusterModel, replica, candidateLogDirs, actionType, optimizedGoals, optimizationOptions);
 
-            if (acceptedBroker != null) {
-                if (broker.utilizationFor(resource()) < this.balanceUpperThreshold) {
+            if (acceptedLogDir != null) {
+                if (logDir.utilizationFor(resource()) < this.balanceUpperThreshold) {
                     return true;
                 }
-                // Remove and reinsert the broker so the order is correct.
+                // Remove and reinsert the logDir so the order is correct.
                 // candidateBrokers.remove(acceptedBroker);
-                candidateBrokers.removeIf(b -> b.id() == acceptedBroker.id());
-                if (acceptedBroker.utilizationFor(resource()) < this.balanceUpperThreshold) {
-                    candidateBrokers.add(acceptedBroker);
+                candidateLogDirs.removeIf(b -> b.broker().id() == acceptedLogDir.broker().id() && b.name().equals(acceptedLogDir.name()));
+                if (acceptedLogDir.utilizationFor(resource()) < this.balanceUpperThreshold) {
+                    candidateLogDirs.add(acceptedLogDir);
                 }
             }
         }
@@ -102,37 +103,37 @@ public abstract class ResourceDistributionGoal extends AbstractGoal {
         return false;
     }
 
-    private boolean rebalanceByMovingLoadIn(Broker broker,
+    private boolean rebalanceByMovingLoadIn(LogDir logDir,
                                             ClusterModel clusterModel,
                                             Set<Goal> optimizedGoals,
                                             ActionType actionType,
                                             OptimizationOptions optimizationOptions) {
-        SortedSet<Broker> candidateBrokers = sortedCandidateBrokersOverThreshold(clusterModel, this.balanceLowerThreshold, optimizationOptions, broker, true);
-        Iterator<Broker> candidateBrokersIt = candidateBrokers.iterator();
-        Broker nextCandidateBroker = null;
+        SortedSet<LogDir> candidateLogDirs = sortedCandidateLogDirsOverThreshold(clusterModel, this.balanceLowerThreshold, optimizationOptions, logDir.broker(), true);
+        Iterator<LogDir> candidateLogDirsIt = candidateLogDirs.iterator();
+        LogDir nextCandidateLogDir = null;
         while (true) {
-            Broker candidateBroker;
-            if (nextCandidateBroker != null) {
-                candidateBroker = nextCandidateBroker;
-                nextCandidateBroker = null;
-            } else if (candidateBrokersIt.hasNext()) {
-                candidateBroker = candidateBrokersIt.next();
+            LogDir candidateLogDir;
+            if (nextCandidateLogDir != null) {
+                candidateLogDir = nextCandidateLogDir;
+                nextCandidateLogDir = null;
+            } else if (candidateLogDirsIt.hasNext()) {
+                candidateLogDir = candidateLogDirsIt.next();
             } else {
                 break;
             }
-            SortedSet<Replica> replicasToMove = sortedCandidateReplicas(candidateBroker, actionType, optimizationOptions, true);
+            SortedSet<Replica> replicasToMove = sortedCandidateReplicas(candidateLogDir, actionType, optimizationOptions, true);
 
             for (Replica replica : replicasToMove) {
-                Broker acceptedBroker = maybeApplyBalancingAction(clusterModel, replica, Collections.singletonList(broker), actionType, optimizedGoals, optimizationOptions);
-                if (acceptedBroker != null) {
-                    if (broker.utilizationFor(resource()) > this.balanceLowerThreshold) {
+                LogDir acceptedLogDir = maybeApplyBalancingAction(clusterModel, replica, Collections.singletonList(logDir), actionType, optimizedGoals, optimizationOptions);
+                if (acceptedLogDir != null) {
+                    if (logDir.utilizationFor(resource()) > this.balanceLowerThreshold) {
                         return true;
                     }
-                    if (candidateBrokersIt.hasNext() || nextCandidateBroker != null) {
-                        if (nextCandidateBroker == null) {
-                            nextCandidateBroker = candidateBrokersIt.next();
+                    if (candidateLogDirsIt.hasNext() || nextCandidateLogDir != null) {
+                        if (nextCandidateLogDir == null) {
+                            nextCandidateLogDir = candidateLogDirsIt.next();
                         }
-                        if (candidateBroker.utilizationFor(resource()) < nextCandidateBroker.utilizationFor(resource())) {
+                        if (candidateLogDir.utilizationFor(resource()) < nextCandidateLogDir.utilizationFor(resource())) {
                             break;
                         }
                     }
@@ -143,14 +144,14 @@ public abstract class ResourceDistributionGoal extends AbstractGoal {
         return false;
     }
 
-    private boolean rebalanceBySwappingLoadOut(Broker broker,
+    private boolean rebalanceBySwappingLoadOut(LogDir logDir,
                                              ClusterModel clusterModel,
                                              Set<Goal> optimizedGoals,
                                              OptimizationOptions optimizationOptions) {
         return false;
     }
 
-    private boolean rebalanceBySwappingLoadIn(Broker broker,
+    private boolean rebalanceBySwappingLoadIn(LogDir logDir,
                                                ClusterModel clusterModel,
                                                Set<Goal> optimizedGoals,
                                                OptimizationOptions optimizationOptions) {
@@ -170,6 +171,21 @@ public abstract class ResourceDistributionGoal extends AbstractGoal {
                 , resource(), reverse);
     }
 
+    private SortedSet<LogDir> sortedCandidateLogDirsUnderThreshold(ClusterModel clusterModel,
+                                                                   double utilizationThreshold,
+                                                                   OptimizationOptions optimizationOptions,
+                                                                   Broker excludedBroker,
+                                                                   boolean reverse) {
+
+        return clusterModel.sortedLogDirsFor(
+                b -> b.utilizationFor(resource()) < utilizationThreshold
+                        && !excludedBroker.equals(b.broker())
+                        // filter brokers
+                        && (optimizationOptions.balanceBrokers().isEmpty() || optimizationOptions.balanceBrokers().contains(b.broker().id()))
+                , resource(), reverse);
+    }
+
+
     private SortedSet<Broker> sortedCandidateBrokersOverThreshold(ClusterModel clusterModel,
                                                                    double utilizationThreshold,
                                                                    OptimizationOptions optimizationOptions,
@@ -180,6 +196,20 @@ public abstract class ResourceDistributionGoal extends AbstractGoal {
                         && !excludedBroker.equals(b)
                         // filter brokers
                         && (optimizationOptions.balanceBrokers().isEmpty() || optimizationOptions.balanceBrokers().contains(b.id()))
+                , resource(), reverse);
+    }
+
+    private SortedSet<LogDir> sortedCandidateLogDirsOverThreshold(ClusterModel clusterModel,
+                                                                   double utilizationThreshold,
+                                                                   OptimizationOptions optimizationOptions,
+                                                                   Broker excludedBroker,
+                                                                   boolean reverse) {
+
+        return clusterModel.sortedLogDirsFor(
+                b -> b.utilizationFor(resource()) > utilizationThreshold
+                        && !excludedBroker.equals(b.broker())
+                        // filter brokers
+                        && (optimizationOptions.balanceBrokers().isEmpty() || optimizationOptions.balanceBrokers().contains(b.broker().id()))
                 , resource(), reverse);
     }
 
@@ -196,12 +226,27 @@ public abstract class ResourceDistributionGoal extends AbstractGoal {
                 , resource(), reverse);
     }
 
+    private SortedSet<Replica> sortedCandidateReplicas(LogDir logDir,
+                                                       ActionType actionType,
+                                                       OptimizationOptions optimizationOptions,
+                                                       boolean reverse) {
+        return logDir.sortedReplicasFor(
+                // exclude topic
+                r -> !optimizationOptions.excludedTopics().contains(r.topicPartition().topic())
+                        && r.load().loadFor(resource()) > 0.0
+                        // LEADERSHIP_MOVEMENT or NW_OUT is require leader replica
+                        && (actionType != ActionType.LEADERSHIP_MOVEMENT && resource() != Resource.NW_OUT || r.isLeader())
+                , resource(), reverse);
+    }
+
     protected abstract Resource resource();
 
     @Override
     protected boolean selfSatisfied(ClusterModel clusterModel, BalancingAction action) {
         Broker destinationBroker = clusterModel.broker(action.destinationBrokerId());
+        LogDir destinationLogDir = destinationBroker.logDir(action.destinationLogDir());
         Broker sourceBroker = clusterModel.broker(action.sourceBrokerId());
+        LogDir sourceLogDir = sourceBroker.logDir(action.sourceLogDir());
         Replica sourceReplica = sourceBroker.replica(action.topicPartition());
 
         Load loadToChange;
@@ -214,8 +259,8 @@ public abstract class ResourceDistributionGoal extends AbstractGoal {
         } else {
             loadToChange = sourceReplica.load();
         }
-        double sourceUtilization = sourceBroker.expectedUtilizationAfterRemove(resource(), loadToChange);
-        double destinationUtilization = destinationBroker.expectedUtilizationAfterAdd(resource(), loadToChange);
+        double sourceUtilization = sourceLogDir.expectedUtilizationAfterRemove(resource(), loadToChange);
+        double destinationUtilization = destinationLogDir.expectedUtilizationAfterAdd(resource(), loadToChange);
 
         return sourceUtilization >= this.balanceLowerThreshold && destinationUtilization <= this.balanceUpperThreshold;
     }

--- a/km-enterprise/km-rebalance/src/main/java/com/xiaojukeji/know/streaming/km/rebalance/algorithm/utils/MetadataUtils.java
+++ b/km-enterprise/km-rebalance/src/main/java/com/xiaojukeji/know/streaming/km/rebalance/algorithm/utils/MetadataUtils.java
@@ -1,15 +1,20 @@
 package com.xiaojukeji.know.streaming.km.rebalance.algorithm.utils;
 
 import org.apache.kafka.clients.*;
+import org.apache.kafka.clients.admin.LogDirDescription;
+import org.apache.kafka.clients.admin.ReplicaInfo;
 import org.apache.kafka.clients.consumer.internals.NoAvailableBrokersException;
 import org.apache.kafka.clients.producer.ProducerConfig;
 import org.apache.kafka.common.Cluster;
 import org.apache.kafka.common.Node;
+import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.message.DescribeLogDirsRequestData;
+import org.apache.kafka.common.message.DescribeLogDirsResponseData;
 import org.apache.kafka.common.network.ChannelBuilder;
 import org.apache.kafka.common.network.NetworkReceive;
 import org.apache.kafka.common.network.Selector;
-import org.apache.kafka.common.requests.MetadataRequest;
-import org.apache.kafka.common.requests.MetadataResponse;
+import org.apache.kafka.common.protocol.Errors;
+import org.apache.kafka.common.requests.*;
 import org.apache.kafka.common.utils.LogContext;
 import org.apache.kafka.common.utils.Time;
 import org.apache.kafka.common.utils.Utils;
@@ -17,9 +22,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
-import java.util.Collections;
-import java.util.List;
-import java.util.Properties;
+import java.util.*;
 
 /**
  * @author leewei
@@ -88,5 +91,88 @@ public class MetadataUtils {
         } finally {
             networkClient.close();
         }
+    }
+
+
+
+
+    public static Map<Integer, Map<String, LogDirDescription>> describeLogDirs(Properties props, List<Node> nodes) {
+        props.setProperty(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, "org.apache.kafka.common.serialization.BytesSerializer");
+        props.setProperty(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, "org.apache.kafka.common.serialization.BytesSerializer");
+        ProducerConfig config = new ProducerConfig(props);
+
+        Time time = Time.SYSTEM;
+        LogContext logContext = new LogContext("Metadata client");
+
+        ChannelBuilder channelBuilder = ClientUtils.createChannelBuilder(config, time, logContext);
+        Selector selector = new Selector(
+                NetworkReceive.UNLIMITED,
+                config.getLong(ProducerConfig.CONNECTIONS_MAX_IDLE_MS_CONFIG),
+                new org.apache.kafka.common.metrics.Metrics(),
+                time,
+                "metadata-client",
+                Collections.singletonMap("client", "metadata-client"),
+                false,
+                channelBuilder,
+                logContext
+        );
+
+        NetworkClient networkClient = new NetworkClient(
+                selector,
+                new ManualMetadataUpdater(),
+                "metadata-client",
+                1,
+                config.getLong(ProducerConfig.RECONNECT_BACKOFF_MS_CONFIG),
+                config.getLong(ProducerConfig.RECONNECT_BACKOFF_MAX_MS_CONFIG),
+                config.getInt(ProducerConfig.SEND_BUFFER_CONFIG),
+                config.getInt(ProducerConfig.RECEIVE_BUFFER_CONFIG),
+                config.getInt(ProducerConfig.REQUEST_TIMEOUT_MS_CONFIG),
+                config.getLong(ProducerConfig.SOCKET_CONNECTION_SETUP_TIMEOUT_MS_CONFIG),
+                config.getLong(ProducerConfig.SOCKET_CONNECTION_SETUP_TIMEOUT_MAX_MS_CONFIG),
+                ClientDnsLookup.DEFAULT,
+                time,
+                true,
+                new ApiVersions(),
+                logContext
+        );
+
+        Map<Integer, Map<String, LogDirDescription>> allDescriptions = new HashMap<>();
+        try {
+            for (int i = 0; i < nodes.size(); i++) {
+                Node sourceNode = nodes.get(i);
+                try {
+                    if (NetworkClientUtils.awaitReady(networkClient, sourceNode, time, 10 * 1000)) {
+                        ClientRequest describeLogDirsRequest = networkClient.newClientRequest(String.valueOf(sourceNode.id()), new DescribeLogDirsRequest.Builder(new DescribeLogDirsRequestData().setTopics(null)), time.milliseconds(), true);
+                        ClientResponse describeLogDirsResponse = NetworkClientUtils.sendAndReceive(networkClient, describeLogDirsRequest, time);
+                        DescribeLogDirsResponse logDirsResponse = (DescribeLogDirsResponse)describeLogDirsResponse.responseBody();
+                        Map<String, LogDirDescription> descriptions = logDirDescriptions(logDirsResponse);
+                        allDescriptions.put(sourceNode.id(), descriptions);
+                    }
+                } catch (IOException e) {
+                    logger.warn("Connection to " + sourceNode + " error", e);
+                    throw new NoAvailableBrokersException();
+                }
+            }
+        } finally {
+            networkClient.close();
+        }
+        return allDescriptions;
+    }
+
+
+    private static Map<String, LogDirDescription> logDirDescriptions(DescribeLogDirsResponse response) {
+        Map<String, LogDirDescription> result = new HashMap<>(response.data().results().size());
+        for (DescribeLogDirsResponseData.DescribeLogDirsResult logDirResult : response.data().results()) {
+            Map<TopicPartition, ReplicaInfo> replicaInfoMap = new HashMap<>();
+            for (DescribeLogDirsResponseData.DescribeLogDirsTopic t : logDirResult.topics()) {
+                for (DescribeLogDirsResponseData.DescribeLogDirsPartition p : t.partitions()) {
+                    replicaInfoMap.put(
+                            new TopicPartition(t.name(), p.partitionIndex()),
+                            new ReplicaInfo(p.partitionSize(), p.offsetLag(), p.isFutureKey()));
+                }
+            }
+            result.put(logDirResult.logDir(), new LogDirDescription(Errors.forCode(logDirResult.errorCode()).exception(), replicaInfoMap));
+        }
+        return result;
     }
 }


### PR DESCRIPTION

## 变更的目的是什么

fix issue https://github.com/didi/KnowStreaming/issues/1164

## 简短的更新日志

集群均衡时，将原有的Node级别的Disk均衡修改为LogDir级别的Disk均衡。初始从broker拉取每个Replica在LogDir上的分布，LogDir总容量默认为broker磁盘总容量/该broekr上LogDir数量 （默认每个LogDir大小相同），由此计算出合理的Replica迁移方案，实现LogDir级别的Disk均衡。



请遵循此清单，以帮助我们快速轻松地整合您的贡献：

* [x] 一个 PR（Pull Request的简写）只解决一个问题，禁止一个 PR 解决多个问题；
* [x] 确保 PR 有对应的 Issue（通常在您开始处理之前创建），除非是书写错误之类的琐碎更改不需要 Issue ；
* [x] 格式化 PR 及 Commit-Log 的标题及内容，例如 #861 。PS：Commit-Log 需要在 Git Commit 代码时进行填写，在 GitHub 上修改不了；
* [x] 编写足够详细的 PR 描述，以了解 PR 的作用、方式和原因；
* [x] 编写必要的单元测试来验证您的逻辑更正。如果提交了新功能或重大更改，请记住在 test 模块中添加 integration-test；
* [x] 确保编译通过，集成测试通过；

