### PR TITLE
[Feature]集群均衡支持LogDir级别的Disk均衡(#1164)

### DIFF
--- a/km-enterprise/km-rebalance/src/main/java/com/xiaojukeji/know/streaming/km/rebalance/algorithm/executor/common/BalanceTask.java
+++ b/km-enterprise/km-rebalance/src/main/java/com/xiaojukeji/know/streaming/km/rebalance/algorithm/executor/common/BalanceTask.java
@@ -7,6 +7,7 @@ public class BalanceTask {
     private int partition;
     //副本分配列表
     private List<Integer> replicas;
+    private List<String> logDirs;
 
     public String getTopic() {
         return topic;
@@ -32,12 +33,21 @@ public class BalanceTask {
         this.replicas = replicas;
     }
 
+    public List<String> getLogDirs() {
+        return logDirs;
+    }
+
+    public void setLogDirs(List<String> logDirs) {
+        this.logDirs = logDirs;
+    }
+
     @Override
     public String toString() {
         return "BalanceTask{" +
                 "topic='" + topic + '\'' +
                 ", partition=" + partition +
                 ", replicas=" + replicas +
+                ", logDirs=" + logDirs +
                 '}';
     }
 }

--- a/km-enterprise/km-rebalance/src/main/java/com/xiaojukeji/know/streaming/km/rebalance/algorithm/executor/common/OptimizerResult.java
+++ b/km-enterprise/km-rebalance/src/main/java/com/xiaojukeji/know/streaming/km/rebalance/algorithm/executor/common/OptimizerResult.java
@@ -120,6 +120,8 @@ public class OptimizerResult {
             task.setPartition(proposal.tp().partition());
             List<Integer> replicas = proposal.newReplicas().stream().map(ReplicaPlacementInfo::brokerId).collect(Collectors.toList());
             task.setReplicas(replicas);
+            List<String> logDirs = proposal.newReplicas().stream().map(ReplicaPlacementInfo::logdir).collect(Collectors.toList());
+            task.setLogDirs(logDirs);
             balanceTasks.add(task);
         });
         return balanceTasks;

--- a/km-enterprise/km-rebalance/src/main/java/com/xiaojukeji/know/streaming/km/rebalance/algorithm/model/LogDir.java
+++ b/km-enterprise/km-rebalance/src/main/java/com/xiaojukeji/know/streaming/km/rebalance/algorithm/model/LogDir.java
@@ -1,0 +1,137 @@
+package com.xiaojukeji.know.streaming.km.rebalance.algorithm.model;
+
+import org.apache.kafka.common.TopicPartition;
+
+import java.util.*;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
+
+public class LogDir implements Comparable<LogDir>{
+
+    private final String name;
+    private final Broker broker;
+    private final Set<Replica> replicas;
+    private final Map<TopicPartition, Replica> topicPartitionReplicas;
+    private final Load load;
+    private final Capacity capacity;
+
+
+    public LogDir(String name, Broker broker, Capacity capacity) {
+        this.name = name;
+        this.broker = broker;
+        this.replicas = new HashSet<>();
+        this.load = new Load();
+        this.capacity = capacity;
+        this.topicPartitionReplicas = new HashMap<>();
+    }
+
+    public void addReplica(Replica replica) {
+        if (this.replicas.contains(replica)) {
+            throw new IllegalStateException(String.format("Broker %d logDir %s already has replica %s", this.broker.id(), this.name,
+                    replica.topicPartition()));
+        }
+        this.replicas.add(replica);
+        this.topicPartitionReplicas.put(replica.topicPartition(), replica);
+        this.load.addLoad(replica.load());
+    }
+
+    Replica removeReplica(TopicPartition topicPartition) {
+        Replica replica = this.topicPartitionReplicas.get(topicPartition);
+        if(replica == null) {
+            return replica;
+        }
+        this.replicas.remove(replica);
+        this.topicPartitionReplicas.remove(topicPartition);
+        this.load.subtractLoad(replica.load());
+        return replica;
+    }
+
+    public Set<Replica> replicas() {
+        return Collections.unmodifiableSet(this.replicas);
+    }
+
+    public String name() {
+        return this.name;
+    }
+
+    public Broker broker() {
+        return this.broker;
+    }
+
+    public Load load() {
+        return this.load;
+    }
+
+    public Capacity capacity() {
+        return this.capacity;
+    }
+
+    public double utilizationFor(Resource resource) {
+        return this.load.loadFor(resource) / this.capacity.capacityFor(resource);
+    }
+
+
+    public double expectedUtilizationAfterAdd(Resource resource, Load loadToChange) {
+        return (this.load.loadFor(resource) + ((loadToChange == null) ? 0 : loadToChange.loadFor(resource)))
+                / this.capacity.capacityFor(resource);
+    }
+
+
+    public double expectedUtilizationAfterRemove(Resource resource, Load loadToChange) {
+        return (this.load.loadFor(resource) - ((loadToChange == null) ? 0 : loadToChange.loadFor(resource)))
+                / this.capacity.capacityFor(resource);
+    }
+
+
+    public SortedSet<Replica> sortedReplicasFor(Predicate<? super Replica> filter, Resource resource, boolean reverse) {
+        Comparator<Replica> comparator =
+                Comparator.<Replica>comparingDouble(r -> r.load().loadFor(resource))
+                        .thenComparingInt(Replica::hashCode);
+        if (reverse)
+            comparator = comparator.reversed();
+        SortedSet<Replica> sortedReplicas = new TreeSet<>(comparator);
+        if (filter == null) {
+            sortedReplicas.addAll(this.replicas);
+        } else {
+            sortedReplicas.addAll(this.replicas.stream()
+                    .filter(filter).collect(Collectors.toList()));
+        }
+
+        return sortedReplicas;
+    }
+
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        LogDir logDir = (LogDir) o;
+        return broker.equals(logDir.broker) && name.equals(logDir.name);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(name, broker.id());
+    }
+
+    @Override
+    public int compareTo(LogDir o) {
+        int rst = Integer.compare(broker.id(), o.broker.id());
+        if(rst != 0) {
+            return rst;
+        } else {
+            return name.compareTo(o.name());
+        }
+    }
+
+    @Override
+    public String toString() {
+        return "LogDir{" +
+                "name=" + name +
+                ", broker='" + broker + '\'' +
+                ", replicas=" + replicas +
+                ", load=" + load +
+                ", capacity=" + capacity +
+                '}';
+    }
+}

--- a/km-enterprise/km-rebalance/src/main/java/com/xiaojukeji/know/streaming/km/rebalance/algorithm/model/Replica.java
+++ b/km-enterprise/km-rebalance/src/main/java/com/xiaojukeji/know/streaming/km/rebalance/algorithm/model/Replica.java
@@ -13,22 +13,24 @@ public class Replica {
     private final Replica original;
     private final TopicPartition topicPartition;
     private Broker broker;
+    private String logDir;
     private boolean isLeader;
     private boolean isOffline;
 
-    public Replica(Broker broker, TopicPartition topicPartition, boolean isLeader, boolean isOffline) {
-        this(broker, topicPartition, isLeader, isOffline, false);
+    public Replica(Broker broker, String logDir, TopicPartition topicPartition, boolean isLeader, boolean isOffline) {
+        this(broker, logDir, topicPartition, isLeader, isOffline, false);
     }
 
-    private Replica(Broker broker, TopicPartition topicPartition, boolean isLeader, boolean isOffline, boolean isOriginal) {
+    private Replica(Broker broker, String logDir, TopicPartition topicPartition, boolean isLeader, boolean isOffline, boolean isOriginal) {
         if (isOriginal) {
             this.original = null;
         } else {
-            this.original = new Replica(broker, topicPartition, isLeader, isOffline, true);
+            this.original = new Replica(broker, logDir, topicPartition, isLeader, isOffline, true);
         }
         this.load = new Load();
         this.topicPartition = topicPartition;
         this.broker = broker;
+        this.logDir = logDir;
         this.isLeader = isLeader;
         this.isOffline = isOffline;
     }
@@ -48,6 +50,14 @@ public class Replica {
     public void setBroker(Broker broker) {
         checkOriginal();
         this.broker = broker;
+    }
+
+    public String logDir() {
+        return logDir;
+    }
+
+    public void setLogDir(String logDir) {
+        this.logDir = logDir;
     }
 
     public boolean isLeader() {

--- a/km-enterprise/km-rebalance/src/main/java/com/xiaojukeji/know/streaming/km/rebalance/algorithm/model/Supplier.java
+++ b/km-enterprise/km-rebalance/src/main/java/com/xiaojukeji/know/streaming/km/rebalance/algorithm/model/Supplier.java
@@ -4,6 +4,7 @@ import com.xiaojukeji.know.streaming.km.rebalance.algorithm.metric.MetricStore;
 import com.xiaojukeji.know.streaming.km.rebalance.algorithm.metric.Metrics;
 import com.xiaojukeji.know.streaming.km.rebalance.algorithm.metric.elasticsearch.ElasticsearchMetricStore;
 import com.xiaojukeji.know.streaming.km.rebalance.algorithm.utils.MetadataUtils;
+import org.apache.kafka.clients.admin.LogDirDescription;
 import org.apache.kafka.clients.producer.ProducerConfig;
 import org.apache.kafka.common.Cluster;
 import org.apache.kafka.common.Node;
@@ -41,9 +42,10 @@ public class Supplier {
         ClusterModel model = new ClusterModel();
         Cluster cluster = MetadataUtils.metadata(kafkaProperties);
 
+        Map<Integer, Map<String, LogDirDescription>> logDirDescriptions = MetadataUtils.describeLogDirs(kafkaProperties, cluster.nodes());
         // nodes
         for (Node node: cluster.nodes()) {
-            addBroker(node, false, model, capacitiesById);
+            addBroker(node, false, model, capacitiesById, logDirDescriptions.get(node.id()).keySet());
         }
 
         // replicas
@@ -84,10 +86,20 @@ public class Supplier {
                     if (isOffline) {
                         if (model.broker(n.id()) == null) {
                             // add offline broker
-                            addBroker(n, true, model, capacitiesById);
+                            addBroker(n, true, model, capacitiesById, logDirDescriptions.get(n.id()).keySet());
                         }
                     }
-                    model.addReplica(n.id(), topicPartition, isLeader, isOffline, isLeader ? leaderLoad : followerLoad);
+
+                    Map<String, LogDirDescription> logDirDescriptionMap = logDirDescriptions.get(n.id());
+                    Optional<String> logDir = logDirDescriptionMap.entrySet()
+                            .stream()
+                            .filter(entry -> entry.getValue().replicaInfos().containsKey(topicPartition))
+                            .map(Map.Entry::getKey)
+                            .findFirst();
+                    if(!logDir.isPresent()) {
+                        throw new IllegalArgumentException("Cannot get logDir of topic partiton:" + topicPartition);
+                    }
+                    model.addReplica(n.id(), logDir.get(), topicPartition, isLeader, isOffline, isLeader ? leaderLoad : followerLoad);
                 }
             }
         });
@@ -98,7 +110,7 @@ public class Supplier {
         return (node.rack() == null || "".equals(node.rack())) ? node.host() : node.rack();
     }
 
-    private static void addBroker(Node node, boolean isOffline, ClusterModel model, Map<Integer, Capacity> capacitiesById) {
+    private static void addBroker(Node node, boolean isOffline, ClusterModel model, Map<Integer, Capacity> capacitiesById, Set<String> logDirs) {
         // rack
         Rack rack = model.addRack(rack(node));
         // broker
@@ -106,7 +118,19 @@ public class Supplier {
         if (capacity == null)
             throw new IllegalArgumentException("Cannot get capacity of node: " + node);
 
-        model.addBroker(rack.id(), node.id(), node.host(), isOffline, capacity);
+        Map<String, Capacity> subCapacities = new HashMap<>();
+        int logDirSize = logDirs.size();
+        for(String name : logDirs) {
+            Capacity subCapacity = new Capacity();
+            // TODO 默认每个logDir大小相同，均分node的资源，需要改为从配置加载
+            subCapacity.setCapacity(Resource.CPU, capacity.capacityFor(Resource.CPU) / logDirSize);
+            subCapacity.setCapacity(Resource.DISK, capacity.capacityFor(Resource.DISK) / logDirSize);
+            subCapacity.setCapacity(Resource.NW_IN, capacity.capacityFor(Resource.NW_IN) / logDirSize);
+            subCapacity.setCapacity(Resource.NW_OUT, capacity.capacityFor(Resource.NW_OUT) / logDirSize);
+            subCapacities.put(name, subCapacity);
+        }
+
+        model.addBroker(rack.id(), node.id(), node.host(), isOffline, capacity, subCapacities);
     }
 
 }

--- a/km-enterprise/km-rebalance/src/main/java/com/xiaojukeji/know/streaming/km/rebalance/algorithm/optimizer/BalancingAction.java
+++ b/km-enterprise/km-rebalance/src/main/java/com/xiaojukeji/know/streaming/km/rebalance/algorithm/optimizer/BalancingAction.java
@@ -5,7 +5,9 @@ import org.apache.kafka.common.TopicPartition;
 public class BalancingAction {
     private final TopicPartition _tp;
     private final Integer _sourceBrokerId;
+    private final String _sourceLogDir;
     private final Integer _destinationBrokerId;
+    private final String _destinationLogDir;
     private final ActionType _actionType;
 
     public BalancingAction(TopicPartition tp,
@@ -14,7 +16,23 @@ public class BalancingAction {
                            ActionType actionType) {
         _tp = tp;
         _sourceBrokerId = sourceBrokerId;
+        _sourceLogDir = "any";
         _destinationBrokerId = destinationBrokerId;
+        _destinationLogDir = "any";
+        _actionType = actionType;
+    }
+
+    public BalancingAction(TopicPartition tp,
+                           Integer sourceBrokerId,
+                           String sourceLogDir,
+                           Integer destinationBrokerId,
+                           String destinationLogDir,
+                           ActionType actionType) {
+        _tp = tp;
+        _sourceBrokerId = sourceBrokerId;
+        _sourceLogDir = sourceLogDir;
+        _destinationBrokerId = destinationBrokerId;
+        _destinationLogDir = destinationLogDir;
         _actionType = actionType;
     }
 
@@ -22,8 +40,16 @@ public class BalancingAction {
         return _sourceBrokerId;
     }
 
+    public String sourceLogDir() {
+        return _sourceLogDir;
+    }
+
     public Integer destinationBrokerId() {
         return _destinationBrokerId;
+    }
+
+    public String destinationLogDir() {
+        return _destinationLogDir;
     }
 
     public ActionType balancingAction() {

--- a/km-enterprise/km-rebalance/src/main/java/com/xiaojukeji/know/streaming/km/rebalance/algorithm/utils/MetadataUtils.java
+++ b/km-enterprise/km-rebalance/src/main/java/com/xiaojukeji/know/streaming/km/rebalance/algorithm/utils/MetadataUtils.java
@@ -1,13 +1,21 @@
 package com.xiaojukeji.know.streaming.km.rebalance.algorithm.utils;
 
 import org.apache.kafka.clients.*;
+import org.apache.kafka.clients.admin.LogDirDescription;
+import org.apache.kafka.clients.admin.ReplicaInfo;
 import org.apache.kafka.clients.consumer.internals.NoAvailableBrokersException;
 import org.apache.kafka.clients.producer.ProducerConfig;
 import org.apache.kafka.common.Cluster;
 import org.apache.kafka.common.Node;
+import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.message.DescribeLogDirsRequestData;
+import org.apache.kafka.common.message.DescribeLogDirsResponseData;
 import org.apache.kafka.common.network.ChannelBuilder;
 import org.apache.kafka.common.network.NetworkReceive;
 import org.apache.kafka.common.network.Selector;
+import org.apache.kafka.common.protocol.Errors;
+import org.apache.kafka.common.requests.DescribeLogDirsRequest;
+import org.apache.kafka.common.requests.DescribeLogDirsResponse;
 import org.apache.kafka.common.requests.MetadataRequest;
 import org.apache.kafka.common.requests.MetadataResponse;
 import org.apache.kafka.common.utils.LogContext;
@@ -17,9 +25,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
-import java.util.Collections;
-import java.util.List;
-import java.util.Properties;
+import java.util.*;
 
 /**
  * @author leewei
@@ -88,5 +94,85 @@ public class MetadataUtils {
         } finally {
             networkClient.close();
         }
+    }
+
+    public static Map<Integer, Map<String, LogDirDescription>> describeLogDirs(Properties props, List<Node> nodes) {
+        props.setProperty(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, "org.apache.kafka.common.serialization.BytesSerializer");
+        props.setProperty(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, "org.apache.kafka.common.serialization.BytesSerializer");
+        ProducerConfig config = new ProducerConfig(props);
+
+        Time time = Time.SYSTEM;
+        LogContext logContext = new LogContext("Metadata client");
+
+        ChannelBuilder channelBuilder = ClientUtils.createChannelBuilder(config, time, logContext);
+        Selector selector = new Selector(
+                NetworkReceive.UNLIMITED,
+                config.getLong(ProducerConfig.CONNECTIONS_MAX_IDLE_MS_CONFIG),
+                new org.apache.kafka.common.metrics.Metrics(),
+                time,
+                "metadata-client",
+                Collections.singletonMap("client", "metadata-client"),
+                false,
+                channelBuilder,
+                logContext
+        );
+
+        NetworkClient networkClient = new NetworkClient(
+                selector,
+                new ManualMetadataUpdater(),
+                "metadata-client",
+                1,
+                config.getLong(ProducerConfig.RECONNECT_BACKOFF_MS_CONFIG),
+                config.getLong(ProducerConfig.RECONNECT_BACKOFF_MAX_MS_CONFIG),
+                config.getInt(ProducerConfig.SEND_BUFFER_CONFIG),
+                config.getInt(ProducerConfig.RECEIVE_BUFFER_CONFIG),
+                config.getInt(ProducerConfig.REQUEST_TIMEOUT_MS_CONFIG),
+                config.getLong(ProducerConfig.SOCKET_CONNECTION_SETUP_TIMEOUT_MS_CONFIG),
+                config.getLong(ProducerConfig.SOCKET_CONNECTION_SETUP_TIMEOUT_MAX_MS_CONFIG),
+                ClientDnsLookup.DEFAULT,
+                time,
+                true,
+                new ApiVersions(),
+                logContext
+        );
+
+        Map<Integer, Map<String, LogDirDescription>> allDescriptions = new HashMap<>();
+        try {
+            for (int i = 0; i < nodes.size(); i++) {
+                Node sourceNode = nodes.get(i);
+                try {
+                    if (NetworkClientUtils.awaitReady(networkClient, sourceNode, time, 10 * 1000)) {
+                        ClientRequest describeLogDirsRequest = networkClient.newClientRequest(String.valueOf(sourceNode.id()), new DescribeLogDirsRequest.Builder(new DescribeLogDirsRequestData().setTopics(null)), time.milliseconds(), true);
+                        ClientResponse describeLogDirsResponse = NetworkClientUtils.sendAndReceive(networkClient, describeLogDirsRequest, time);
+                        DescribeLogDirsResponse logDirsResponse = (DescribeLogDirsResponse)describeLogDirsResponse.responseBody();
+                        Map<String, LogDirDescription> descriptions = logDirDescriptions(logDirsResponse);
+                        allDescriptions.put(sourceNode.id(), descriptions);
+                    }
+                } catch (IOException e) {
+                    logger.warn("Connection to " + sourceNode + " error", e);
+                    throw new NoAvailableBrokersException();
+                }
+            }
+        } finally {
+            networkClient.close();
+        }
+        return allDescriptions;
+    }
+
+
+    private static Map<String, LogDirDescription> logDirDescriptions(DescribeLogDirsResponse response) {
+        Map<String, LogDirDescription> result = new HashMap<>(response.data().results().size());
+        for (DescribeLogDirsResponseData.DescribeLogDirsResult logDirResult : response.data().results()) {
+            Map<TopicPartition, ReplicaInfo> replicaInfoMap = new HashMap<>();
+            for (DescribeLogDirsResponseData.DescribeLogDirsTopic t : logDirResult.topics()) {
+                for (DescribeLogDirsResponseData.DescribeLogDirsPartition p : t.partitions()) {
+                    replicaInfoMap.put(
+                            new TopicPartition(t.name(), p.partitionIndex()),
+                            new ReplicaInfo(p.partitionSize(), p.offsetLag(), p.isFutureKey()));
+                }
+            }
+            result.put(logDirResult.logDir(), new LogDirDescription(Errors.forCode(logDirResult.errorCode()).exception(), replicaInfoMap));
+        }
+        return result;
     }
 }


### PR DESCRIPTION

## 变更的目的是什么

fix issue https://github.com/didi/KnowStreaming/issues/1164

## 简短的更新日志
集群均衡时，将原有的Node级别的Disk均衡修改为LogDir级别的Disk均衡。初始从broker拉取每个Replica在LogDir上的分布，LogDir总容量默认为broker磁盘总容量/该broekr上LogDir数量 （默认每个LogDir大小相同），由此计算出合理的Replica迁移方案，实现LogDir级别的Disk均衡。



请遵循此清单，以帮助我们快速轻松地整合您的贡献：

* [x] 一个 PR（Pull Request的简写）只解决一个问题，禁止一个 PR 解决多个问题；
* [x] 确保 PR 有对应的 Issue（通常在您开始处理之前创建），除非是书写错误之类的琐碎更改不需要 Issue ；
* [x] 格式化 PR 及 Commit-Log 的标题及内容，例如 #861 。PS：Commit-Log 需要在 Git Commit 代码时进行填写，在 GitHub 上修改不了；
* [x] 编写足够详细的 PR 描述，以了解 PR 的作用、方式和原因；
* [x] 编写必要的单元测试来验证您的逻辑更正。如果提交了新功能或重大更改，请记住在 test 模块中添加 integration-test；
* [x] 确保编译通过，集成测试通过；

