### PR TITLE
[Bugfix] 修复BrokerConfigServiceImpl类中的getBrokerConfigByZKClient方法一定返回空…

### DIFF
--- a/km-core/src/main/java/com/xiaojukeji/know/streaming/km/core/service/broker/impl/BrokerConfigServiceImpl.java
+++ b/km-core/src/main/java/com/xiaojukeji/know/streaming/km/core/service/broker/impl/BrokerConfigServiceImpl.java
@@ -37,6 +37,7 @@ import scala.jdk.javaapi.CollectionConverters;
 
 import javax.annotation.PostConstruct;
 import java.util.*;
+import java.util.stream.Collectors;
 
 import static com.xiaojukeji.know.streaming.km.common.enums.version.VersionEnum.*;
 
@@ -154,9 +155,11 @@ public class BrokerConfigServiceImpl extends BaseKafkaVersionControlService impl
         if (propertiesResult.failed()) {
             return Result.buildFromIgnoreData(propertiesResult);
         }
+        List<String> configKeyList = propertiesResult.getData().keySet().stream().map(Object::toString).collect(Collectors.toList());
+
 
         return Result.buildSuc(KafkaConfigConverter.convert2KafkaBrokerConfigDetailList(
-                new ArrayList<>(),
+                configKeyList,
                 propertiesResult.getData()
         ));
     }


### PR DESCRIPTION
…列表 (#1086)

请不要在没有先创建Issue的情况下创建Pull Request。

## 变更的目的是什么

修复1086 空列表

## 简短的更新日志

修复1086 空列表

## 验证这一变化

修复1086 空列表问题


