### PR TITLE
[Feature] consumer列表支持按status和member数量排序(#875)

### DIFF
--- a/km-biz/src/main/java/com/xiaojukeji/know/streaming/km/biz/group/impl/GroupManagerImpl.java
+++ b/km-biz/src/main/java/com/xiaojukeji/know/streaming/km/biz/group/impl/GroupManagerImpl.java
@@ -174,7 +174,7 @@ public class GroupManagerImpl implements GroupManager {
         }
 
         // 分页 后 返回
-        return PaginationUtil.pageBySubData(voList, dto);
+        return PaginationUtil.pageBySubData( PaginationUtil.pageBySort(voList, dto.getSortField(), dto.getSortType(),"memberCount", dto.getSortType()), dto);
     }
 
     @Override

--- a/km-common/src/main/java/com/xiaojukeji/know/streaming/km/common/bean/dto/cluster/ClusterGroupSummaryDTO.java
+++ b/km-common/src/main/java/com/xiaojukeji/know/streaming/km/common/bean/dto/cluster/ClusterGroupSummaryDTO.java
@@ -1,6 +1,6 @@
 package com.xiaojukeji.know.streaming.km.common.bean.dto.cluster;
 
-import com.xiaojukeji.know.streaming.km.common.bean.dto.pagination.PaginationBaseDTO;
+import com.xiaojukeji.know.streaming.km.common.bean.dto.pagination.PaginationSortDTO;
 import io.swagger.annotations.ApiModelProperty;
 import lombok.Data;
 
@@ -9,7 +9,7 @@ import lombok.Data;
  * @date 2022/10/17
  */
 @Data
-public class ClusterGroupSummaryDTO extends PaginationBaseDTO {
+public class ClusterGroupSummaryDTO extends PaginationSortDTO {
     @ApiModelProperty("查找该Topic")
     private String searchTopicName;
 


### PR DESCRIPTION


## 变更的目的是什么

consumer列表支持按status和member数量排序后端实现接口

## 简短的更新日志

consumer列表支持按status和member数量排序后端实现接口

## 验证这一变化

consumer列表支持按status和member数量排序后端实现接口

